### PR TITLE
feat: add obsidian vault bootstrap script

### DIFF
--- a/scripts/bootstrap-vault
+++ b/scripts/bootstrap-vault
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Bootstrap the obsidian-vault git repo at ~/obsidian-vault.
+# Usage:
+#   bootstrap-vault                  init a fresh local repo
+#   bootstrap-vault <remote-url>     clone an existing remote
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+log()     { echo -e "${BLUE}[vault]${NC} $1"; }
+success() { echo -e "${GREEN}[ok]${NC} $1"; }
+warn()    { echo -e "${YELLOW}[warn]${NC} $1"; }
+error()   { echo -e "${RED}[error]${NC} $1"; exit 1; }
+
+VAULT_DIR="$HOME/obsidian-vault"
+REMOTE="${1:-}"
+
+if [[ -d "$VAULT_DIR/.git" ]]; then
+  success "Vault already initialised at $VAULT_DIR — nothing to do."
+  exit 0
+fi
+
+if [[ -n "$REMOTE" ]]; then
+  log "Cloning $REMOTE → $VAULT_DIR"
+  git clone "$REMOTE" "$VAULT_DIR"
+else
+  log "Initialising new git repo at $VAULT_DIR"
+  mkdir -p "$VAULT_DIR"
+  git -C "$VAULT_DIR" init
+  git -C "$VAULT_DIR" checkout -b main
+fi
+
+# Directories expected by obsidian.nvim workspace config
+mkdir -p "$VAULT_DIR/daily" "$VAULT_DIR/templates"
+success "Created daily/ and templates/"
+
+# Keep Obsidian's local workspace state out of git
+GITIGNORE="$VAULT_DIR/.gitignore"
+if [[ ! -f "$GITIGNORE" ]]; then
+  cat > "$GITIGNORE" <<'EOF'
+.obsidian/workspace.json
+.obsidian/workspace-mobile.json
+.trash/
+EOF
+  success "Created .gitignore"
+fi
+
+if [[ -z "$REMOTE" ]]; then
+  git -C "$VAULT_DIR" add -A
+  git -C "$VAULT_DIR" commit -m "chore: initial vault scaffold"
+  echo ""
+  warn "No remote set. To push:"
+  echo "  git -C $VAULT_DIR remote add origin <url>"
+  echo "  git -C $VAULT_DIR push -u origin main"
+fi
+
+echo ""
+success "Vault ready at $VAULT_DIR"


### PR DESCRIPTION
## Summary

- Adds \`scripts/bootstrap-vault\`, a standalone script that initialises \`~/obsidian-vault\` as a git repository
- Supports two modes: clone an existing remote (\`bootstrap-vault <url>\`) or init a fresh local repo
- Creates the \`daily/\` and \`templates/\` directories expected by the obsidian.nvim workspace config
- Drops a \`.gitignore\` to exclude Obsidian's local workspace state files from git
- Follows the same colored-output style as \`install.sh\`

## Test plan

- [ ] Run \`scripts/bootstrap-vault\` on a machine without \`~/obsidian-vault\` — verify repo init, folders, and .gitignore are created
- [ ] Run again — verify "already initialised" early-exit works
- [ ] Run \`scripts/bootstrap-vault <remote-url>\` — verify clone path works

🤖 Generated with [Claude Code](https://claude.com/claude-code)