### PR TITLE
feat: add Doom Emacs config

### DIFF
--- a/doom/config.el
+++ b/doom/config.el
@@ -1,0 +1,133 @@
+;;; $DOOMDIR/config.el -*- lexical-binding: t; -*-
+
+;; Place your private configuration here! Remember, you do not need to run 'doom
+;; sync' after modifying this file!
+
+
+;; Some functionality uses this to identify you, e.g. GPG configuration, email
+;; clients, file templates and snippets. It is optional.
+;; (setq user-full-name "John Doe"
+;;       user-mail-address "john@doe.com")
+
+;; Doom exposes five (optional) variables for controlling fonts in Doom:
+;;
+;; - `doom-font' -- the primary font to use
+;; - `doom-variable-pitch-font' -- a non-monospace font (where applicable)
+;; - `doom-big-font' -- used for `doom-big-font-mode'; use this for
+;;   presentations or streaming.
+;; - `doom-symbol-font' -- for symbols
+;; - `doom-serif-font' -- for the `fixed-pitch-serif' face
+;;
+;; See 'C-h v doom-font' for documentation and more examples of what they
+;; accept. For example:
+;;
+;;(setq doom-font (font-spec :family "Fira Code" :size 12 :weight 'semi-light)
+;;      doom-variable-pitch-font (font-spec :family "Fira Sans" :size 13))
+;;
+;; If you or Emacs can't find your font, use 'M-x describe-font' to look them
+;; up, `M-x eval-region' to execute elisp code, and 'M-x doom/reload-font' to
+;; refresh your font settings. If Emacs still can't find your font, it likely
+;; wasn't installed correctly. Font issues are rarely Doom issues!
+
+;; There are two ways to load a theme. Both assume the theme is installed and
+;; available. You can either set `doom-theme' or manually load a theme with the
+;; `load-theme' function. This is the default:
+(setq doom-theme 'doom-one)
+
+;; This determines the style of line numbers in effect. If set to `nil', line
+;; numbers are disabled. For relative line numbers, set this to `relative'.
+(setq display-line-numbers-type t)
+
+;; If you use `org' and don't want your org files in the default location below,
+;; change `org-directory'. It must be set before org loads!
+(setq org-directory "~/org/")
+
+;; Go debugger (delve via dape — dlv config built-in)
+(after! dape
+  (setq dape-buffer-window-arrangement 'right))
+
+;; Go test runner (go.work workspace aware)
+(defun +go/module-root ()
+  "Find nearest go.mod directory from current buffer."
+  (locate-dominating-file (buffer-file-name) "go.mod"))
+
+(defun +go/test-current-file ()
+  "Run tests in current file's package."
+  (interactive)
+  (let ((mod-root (+go/module-root)))
+    (compile (format "cd %s && go test -v %s"
+                     mod-root
+                     (concat "./" (file-relative-name
+                                   (file-name-directory (buffer-file-name))
+                                   mod-root))))))
+
+(defun +go/test-current-function ()
+  "Run test function at point."
+  (interactive)
+  (let ((func (which-function))
+        (mod-root (+go/module-root)))
+    (if func
+        (compile (format "cd %s && go test -v -run %s ./..."
+                         mod-root func))
+      (message "No function at point"))))
+
+(defun +go/test-all ()
+  "Run all tests in current module."
+  (interactive)
+  (compile (format "cd %s && go test -v ./..." (+go/module-root))))
+
+(defun +go/test-all-race ()
+  "Run all tests with race detector in current module."
+  (interactive)
+  (compile (format "cd %s && go test -v -race ./..." (+go/module-root))))
+
+(after! go-mode
+  (map! :localleader
+        :map go-mode-map
+        (:prefix ("d" . "debug")
+         :desc "Debug program"       "d" #'dape
+         :desc "Debug last"          "l" #'dape-restart
+         :desc "Toggle breakpoint"   "b" #'dape-breakpoint-toggle
+         :desc "Continue"            "c" #'dape-continue
+         :desc "Next"                "n" #'dape-next
+         :desc "Step in"             "i" #'dape-step-in
+         :desc "Step out"            "o" #'dape-step-out
+         :desc "Quit"                "q" #'dape-quit)
+        (:prefix ("t" . "test")
+         :desc "Test at point"  "t" #'+go/test-current-function
+         :desc "Test file"      "f" #'+go/test-current-file
+         :desc "Test all"       "a" #'+go/test-all
+         :desc "Test all+race"  "r" #'+go/test-all-race)))
+
+
+;; Whenever you reconfigure a package, make sure to wrap your config in an
+;; `after!' block, otherwise Doom's defaults may override your settings. E.g.
+;;
+;;   (after! PACKAGE
+;;     (setq x y))
+;;
+;; The exceptions to this rule:
+;;
+;;   - Setting file/directory variables (like `org-directory')
+;;   - Setting variables which explicitly tell you to set them before their
+;;     package is loaded (see 'C-h v VARIABLE' to look up their documentation).
+;;   - Setting doom variables (which start with 'doom-' or '+').
+;;
+;; Here are some additional functions/macros that will help you configure Doom.
+;;
+;; - `load!' for loading external *.el files relative to this one
+;; - `use-package!' for configuring packages
+;; - `after!' for running code after a package has loaded
+;; - `add-load-path!' for adding directories to the `load-path', relative to
+;;   this file. Emacs searches the `load-path' when you load packages with
+;;   `require' or `use-package'.
+;; - `map!' for binding new keys
+;;
+;; To get information about any of these functions/macros, move the cursor over
+;; the highlighted symbol at press 'K' (non-evil users must press 'C-c c k').
+;; This will open documentation for it, including demos of how they are used.
+;; Alternatively, use `C-h o' to look up a symbol (functions, variables, faces,
+;; etc).
+;;
+;; You can also try 'gd' (or 'C-c c d') to jump to their definition and see how
+;; they are implemented.

--- a/doom/config.el
+++ b/doom/config.el
@@ -42,9 +42,64 @@
 ;; change `org-directory'. It must be set before org loads!
 (setq org-directory "~/org/")
 
-;; Go debugger (delve via dape — dlv config built-in)
+;; Tune gopls (match nvim setup: inlay hints, codelenses, gofumpt, full analyses)
+(after! lsp-go
+  (setq lsp-go-analyses
+        '((unusedparams . t)
+          (unusedwrite . t)
+          (shadow . t)
+          (useany . t)
+          (nilness . t))
+        lsp-go-use-gofumpt t
+        lsp-go-codelenses
+        '((generate . t)
+          (gc_details . t)
+          (run_govulncheck . t)
+          (tidy . t)
+          (upgrade_dependency . t)
+          (vendor . t))
+        lsp-go-hints
+        '((assignVariableTypes . t)
+          (compositeLiteralFields . t)
+          (compositeLiteralTypes . t)
+          (constantValues . t)
+          (functionTypeParameters . t)
+          (parameterNames . t)
+          (rangeVariableTypes . t))))
+
+(after! lsp-mode
+  (setq lsp-inlay-hint-enable t
+        lsp-enable-snippet t
+        lsp-completion-enable-additional-text-edit t
+        lsp-signature-auto-activate t
+        lsp-signature-render-documentation t))
+
+;; Inline doc popup (like nvim's hover with K)
+(after! lsp-ui
+  (setq lsp-ui-doc-enable t
+        lsp-ui-doc-show-with-cursor nil   ; only on demand, not auto
+        lsp-ui-doc-show-with-mouse nil
+        lsp-ui-doc-position 'at-point
+        lsp-ui-doc-max-width 80
+        lsp-ui-doc-max-height 25
+        lsp-ui-doc-delay 0.2
+        lsp-ui-doc-include-signature t
+        lsp-ui-sideline-enable t
+        lsp-ui-sideline-show-hover nil
+        lsp-ui-sideline-show-diagnostics t
+        lsp-ui-sideline-show-code-actions t)
+  (map! :map lsp-mode-map
+        :n "K" #'lsp-ui-doc-glance
+        :leader
+        (:prefix ("c" . "code")
+         :desc "Toggle doc frame" "K" #'lsp-ui-doc-show
+         :desc "Focus doc frame"  "k" #'lsp-ui-doc-focus-frame)))
+
+;; Go debugger (delve via dape) — split layout like nvim dap-ui
 (after! dape
-  (setq dape-buffer-window-arrangement 'right))
+  (setq dape-buffer-window-arrangement 'gud
+        dape-info-hide-mode-line nil
+        dape-stack-trace-levels 10))
 
 ;; Go test runner (go.work workspace aware)
 (defun +go/module-root ()
@@ -99,6 +154,58 @@
          :desc "Test all"       "a" #'+go/test-all
          :desc "Test all+race"  "r" #'+go/test-all-race)))
 
+
+;; vterm
+(after! vterm
+  (setq vterm-max-scrollback 10000))
+
+;; Better autocomplete (corfu tuning + cape sources + icons)
+(after! corfu
+  (setq corfu-auto t
+        corfu-auto-delay 0.1
+        corfu-auto-prefix 1
+        corfu-preselect 'first
+        corfu-cycle t
+        corfu-quit-no-match 'separator
+        corfu-preview-current 'insert
+        corfu-popupinfo-delay '(0.3 . 0.2))
+  (corfu-popupinfo-mode 1)
+  (with-eval-after-load 'kind-icon
+    (setq kind-icon-default-face 'corfu-default)
+    (add-to-list 'corfu-margin-formatters #'kind-icon-margin-formatter)))
+
+(use-package! kind-icon
+  :after corfu
+  :config
+  (setq kind-icon-use-icons t
+        kind-icon-blend-background nil))
+
+;; Cape: extra completion sources
+(after! cape
+  (add-to-list 'completion-at-point-functions #'cape-file)
+  (add-to-list 'completion-at-point-functions #'cape-dabbrev)
+  (add-to-list 'completion-at-point-functions #'cape-keyword))
+
+;; Projectile: auto-discover projects (like nvim-project depth=2 under ~/Documents)
+(after! projectile
+  (setq projectile-project-search-path '(("~/Documents/" . 2))
+        projectile-auto-discover t
+        projectile-enable-caching t
+        projectile-sort-order 'recently-active))
+
+;; Prettier Go test output via gotest
+(use-package! gotest
+  :after go-mode
+  :init
+  (after! go-mode
+    (map! :localleader
+          :map go-mode-map
+          (:prefix ("T" . "gotest pretty")
+           :desc "Test at point"  "t" #'go-test-current-test
+           :desc "Test file"      "f" #'go-test-current-file
+           :desc "Test project"   "a" #'go-test-current-project
+           :desc "Benchmark"      "b" #'go-test-current-benchmark
+           :desc "Coverage"       "c" #'go-test-current-coverage))))
 
 ;; Whenever you reconfigure a package, make sure to wrap your config in an
 ;; `after!' block, otherwise Doom's defaults may override your settings. E.g.

--- a/doom/init.el
+++ b/doom/init.el
@@ -1,0 +1,199 @@
+;;; init.el -*- lexical-binding: t; -*-
+
+;; This file controls what Doom modules are enabled and what order they load
+;; in. Remember to run 'doom sync' after modifying it!
+
+;; NOTE Press 'SPC h d h' (or 'C-h d h' for non-vim users) to access Doom's
+;;      documentation. There you'll find a link to Doom's Module Index where all
+;;      of our modules are listed, including what flags they support.
+
+;; NOTE Move your cursor over a module's name (or its flags) and press 'K' (or
+;;      'C-c c k' for non-vim users) to view its documentation. This works on
+;;      flags as well (those symbols that start with a plus).
+;;
+;;      Alternatively, press 'gd' (or 'C-c c d') on a module to browse its
+;;      directory (for easy access to its source code).
+
+(doom! :input
+       ;;bidi              ; (tfel ot) thgir etirw uoy gnipleh
+       ;;chinese
+       ;;japanese
+       ;;layout            ; auie,ctsrnm is the superior home row
+
+       :completion
+       ;;company           ; the ultimate code completion backend
+       (corfu +orderless)  ; complete with cap(f), cape and a flying feather!
+       ;;helm              ; the *other* search engine for love and life
+       ;;ido               ; the other *other* search engine...
+       ;;ivy               ; a search engine for love and life
+       vertico           ; the search engine of the future
+
+       :ui
+       ;;deft              ; notational velocity for Emacs
+       doom              ; what makes DOOM look the way it does
+       doom-dashboard    ; a nifty splash screen for Emacs
+       ;;doom-quit         ; DOOM quit-message prompts when you quit Emacs
+       ;;(emoji +unicode)  ; 🙂
+       hl-todo           ; highlight TODO/FIXME/NOTE/DEPRECATED/HACK/REVIEW
+       ;;indent-guides     ; highlighted indent columns
+       ;;ligatures         ; ligatures and symbols to make your code pretty again
+       ;;minimap           ; show a map of the code on the side
+       modeline          ; snazzy, Atom-inspired modeline, plus API
+       ;;nav-flash         ; blink cursor line after big motions
+       ;;neotree           ; a project drawer, like NERDTree for vim
+       ophints           ; highlight the region an operation acts on
+       (popup +defaults)   ; tame sudden yet inevitable temporary windows
+       ;;smooth-scroll     ; So smooth you won't believe it's not butter
+       ;;tabs              ; a tab bar for Emacs
+       treemacs          ; a project drawer, like neotree but cooler
+       ;;unicode           ; extended unicode support for various languages
+       (vc-gutter +pretty) ; vcs diff in the fringe
+       vi-tilde-fringe   ; fringe tildes to mark beyond EOB
+       ;;window-select     ; visually switch windows
+       workspaces        ; tab emulation, persistence & separate workspaces
+       ;;zen               ; distraction-free coding or writing
+
+       :editor
+       (evil +everywhere); come to the dark side, we have cookies
+       file-templates    ; auto-snippets for empty files
+       fold              ; (nigh) universal code folding
+       ;;(format +onsave)  ; automated prettiness
+       ;;god               ; run Emacs commands without modifier keys
+       ;;lispy             ; vim for lisp, for people who don't like vim
+       ;;multiple-cursors  ; editing in many places at once
+       ;;objed             ; text object editing for the innocent
+       ;;parinfer          ; turn lisp into python, sort of
+       ;;rotate-text       ; cycle region at point between text candidates
+       snippets          ; my elves. They type so I don't have to
+       (whitespace +guess +trim)  ; a butler for your whitespace
+       ;;word-wrap         ; soft wrapping with language-aware indent
+
+       :emacs
+       dired             ; making dired pretty [functional]
+       electric          ; smarter, keyword-based electric-indent
+       ;;eww               ; the internet is gross
+       ;;ibuffer           ; interactive buffer management
+       tramp             ; remote files at your arthritic fingertips
+       undo              ; persistent, smarter undo for your inevitable mistakes
+       vc                ; version-control and Emacs, sitting in a tree
+
+       :term
+       ;;eshell            ; the elisp shell that works everywhere
+       ;;shell             ; simple shell REPL for Emacs
+       ;;term              ; basic terminal emulator for Emacs
+       ;;vterm             ; the best terminal emulation in Emacs
+
+       :checkers
+       syntax              ; tasing you for every semicolon you forget
+       ;;(spell +flyspell) ; tasing you for misspelling mispelling
+       ;;grammar           ; tasing grammar mistake every you make
+
+       :tools
+       ;;ansible
+       ;;biblio            ; Writes a PhD for you (citation needed)
+       ;;collab            ; buffers with friends
+       debugger          ; stepping through code, to help you add bugs
+       ;;direnv
+       ;;docker
+       ;;editorconfig      ; let someone else argue about tabs vs spaces
+       ;;ein               ; tame Jupyter notebooks with emacs
+       (eval +overlay)     ; run code, run (also, repls)
+       lookup              ; navigate your code and its documentation
+       ;;llm               ; when I said you needed friends, I didn't mean...
+       ;;(lsp +eglot)      ; M-x vscode
+       lsp
+       magit             ; a git porcelain for Emacs
+       ;;make              ; run make tasks from Emacs
+       ;;pass              ; password manager for nerds
+       ;;pdf               ; pdf enhancements
+       ;;terraform         ; infrastructure as code
+       ;;tmux              ; an API for interacting with tmux
+       tree-sitter       ; syntax and parsing, sitting in a tree...
+       ;;upload            ; map local to remote projects via ssh/ftp
+
+       :os
+       (:if (featurep :system 'macos) macos)  ; improve compatibility with macOS
+       ;;tty               ; improve the terminal Emacs experience
+
+       :lang
+       ;;ada               ; In strong typing we (blindly) trust
+       ;;agda              ; types of types of types of types...
+       ;;beancount         ; mind the GAAP
+       ;;(cc +lsp)         ; C > C++ == 1
+       ;;clojure           ; java with a lisp
+       ;;common-lisp       ; if you've seen one lisp, you've seen them all
+       ;;coq               ; proofs-as-programs
+       ;;crystal           ; ruby at the speed of c
+       ;;csharp            ; unity, .NET, and mono shenanigans
+       ;;data              ; config/data formats
+       ;;(dart +flutter)   ; paint ui and not much else
+       ;;dhall
+       ;;elixir            ; erlang done right
+       ;;elm               ; care for a cup of TEA?
+       emacs-lisp        ; drown in parentheses
+       ;;erlang            ; an elegant language for a more civilized age
+       ;;ess               ; emacs speaks statistics
+       ;;factor
+       ;;faust             ; dsp, but you get to keep your soul
+       ;;fortran           ; in FORTRAN, GOD is REAL (unless declared INTEGER)
+       ;;fsharp            ; ML stands for Microsoft's Language
+       ;;fstar             ; (dependent) types and (monadic) effects and Z3
+       ;;gdscript          ; the language you waited for
+       (go +lsp)         ; the hipster dialect
+       ;;(graphql +lsp)    ; Give queries a REST
+       ;;(haskell +lsp)    ; a language that's lazier than I am
+       ;;hy                ; readability of scheme w/ speed of python
+       ;;idris             ; a language you can depend on
+       ;;json              ; At least it ain't XML
+       ;;janet             ; Fun fact: Janet is me!
+       ;;(java +lsp)       ; the poster child for carpal tunnel syndrome
+       ;;javascript        ; all(hope(abandon(ye(who(enter(here))))))
+       ;;julia             ; a better, faster MATLAB
+       ;;kotlin            ; a better, slicker Java(Script)
+       ;;latex             ; writing papers in Emacs has never been so fun
+       ;;lean              ; for folks with too much to prove
+       ;;ledger            ; be audit you can be
+       ;;lua               ; one-based indices? one-based indices
+       markdown          ; writing docs for people to ignore
+       ;;nim               ; python + lisp at the speed of c
+       ;;nix               ; I hereby declare "nix geht mehr!"
+       ;;ocaml             ; an objective camel
+       org               ; organize your plain life in plain text
+       ;;php               ; perl's insecure younger brother
+       ;;plantuml          ; diagrams for confusing people more
+       ;;graphviz          ; diagrams for confusing yourself even more
+       ;;purescript        ; javascript, but functional
+       ;;python            ; beautiful is better than ugly
+       ;;qt                ; the 'cutest' gui framework ever
+       ;;racket            ; a DSL for DSLs
+       ;;raku              ; the artist formerly known as perl6
+       ;;rest              ; Emacs as a REST client
+       ;;rst               ; ReST in peace
+       ;;(ruby +rails)     ; 1.step {|i| p "Ruby is #{i.even? ? 'love' : 'life'}"}
+       ;;(rust +lsp)       ; Fe2O3.unwrap().unwrap().unwrap().unwrap()
+       ;;scala             ; java, but good
+       ;;(scheme +guile)   ; a fully conniving family of lisps
+       sh                ; she sells {ba,z,fi}sh shells on the C xor
+       ;;sml
+       ;;solidity          ; do you need a blockchain? No.
+       ;;swift             ; who asked for emoji variables?
+       ;;terra             ; Earth and Moon in alignment for performance.
+       ;;web               ; the tubes
+       ;;yaml              ; JSON, but readable
+       ;;zig               ; C, but simpler
+
+       :email
+       ;;(mu4e +org +gmail)
+       ;;notmuch
+       ;;(wanderlust +gmail)
+
+       :app
+       ;;calendar
+       ;;emms
+       ;;everywhere        ; *leave* Emacs!? You must be joking
+       ;;irc               ; how neckbeards socialize
+       ;;(rss +org)        ; emacs as an RSS reader
+
+       :config
+       ;;literate
+       (default +bindings +smartparens))

--- a/doom/init.el
+++ b/doom/init.el
@@ -57,7 +57,7 @@
        (evil +everywhere); come to the dark side, we have cookies
        file-templates    ; auto-snippets for empty files
        fold              ; (nigh) universal code folding
-       ;;(format +onsave)  ; automated prettiness
+       (format +onsave)  ; automated prettiness
        ;;god               ; run Emacs commands without modifier keys
        ;;lispy             ; vim for lisp, for people who don't like vim
        ;;multiple-cursors  ; editing in many places at once
@@ -81,7 +81,7 @@
        ;;eshell            ; the elisp shell that works everywhere
        ;;shell             ; simple shell REPL for Emacs
        ;;term              ; basic terminal emulator for Emacs
-       ;;vterm             ; the best terminal emulation in Emacs
+       vterm             ; the best terminal emulation in Emacs
 
        :checkers
        syntax              ; tasing you for every semicolon you forget
@@ -93,7 +93,7 @@
        ;;biblio            ; Writes a PhD for you (citation needed)
        ;;collab            ; buffers with friends
        debugger          ; stepping through code, to help you add bugs
-       ;;direnv
+       direnv
        ;;docker
        ;;editorconfig      ; let someone else argue about tabs vs spaces
        ;;ein               ; tame Jupyter notebooks with emacs
@@ -107,7 +107,7 @@
        ;;pass              ; password manager for nerds
        ;;pdf               ; pdf enhancements
        ;;terraform         ; infrastructure as code
-       ;;tmux              ; an API for interacting with tmux
+       tmux              ; an API for interacting with tmux
        tree-sitter       ; syntax and parsing, sitting in a tree...
        ;;upload            ; map local to remote projects via ssh/ftp
 
@@ -167,7 +167,7 @@
        ;;qt                ; the 'cutest' gui framework ever
        ;;racket            ; a DSL for DSLs
        ;;raku              ; the artist formerly known as perl6
-       ;;rest              ; Emacs as a REST client
+       rest              ; Emacs as a REST client
        ;;rst               ; ReST in peace
        ;;(ruby +rails)     ; 1.step {|i| p "Ruby is #{i.even? ? 'love' : 'life'}"}
        ;;(rust +lsp)       ; Fe2O3.unwrap().unwrap().unwrap().unwrap()

--- a/doom/packages.el
+++ b/doom/packages.el
@@ -1,0 +1,54 @@
+;; -*- no-byte-compile: t; -*-
+;;; $DOOMDIR/packages.el
+
+;; To install a package:
+;;
+;;   1. Declare them here in a `package!' statement,
+;;   2. Run 'doom sync' in the shell,
+;;   3. Restart Emacs.
+;;
+;; Use 'C-h f package\!' to look up documentation for the `package!' macro.
+
+
+;; To install SOME-PACKAGE from MELPA, ELPA or emacsmirror:
+;; (package! some-package)
+
+;; To install a package directly from a remote git repo, you must specify a
+;; `:recipe'. You'll find documentation on what `:recipe' accepts here:
+;; https://github.com/radian-software/straight.el#the-recipe-format
+;; (package! another-package
+;;   :recipe (:host github :repo "username/repo"))
+
+;; If the package you are trying to install does not contain a PACKAGENAME.el
+;; file, or is located in a subdirectory of the repo, you'll need to specify
+;; `:files' in the `:recipe':
+;; (package! this-package
+;;   :recipe (:host github :repo "username/repo"
+;;            :files ("some-file.el" "src/lisp/*.el")))
+
+;; If you'd like to disable a package included with Doom, you can do so here
+;; with the `:disable' property:
+;; (package! builtin-package :disable t)
+
+;; You can override the recipe of a built in package without having to specify
+;; all the properties for `:recipe'. These will inherit the rest of its recipe
+;; from Doom or MELPA/ELPA/Emacsmirror:
+;; (package! builtin-package :recipe (:nonrecursive t))
+;; (package! builtin-package-2 :recipe (:repo "myfork/package"))
+
+;; Specify a `:branch' to install a package from a particular branch or tag.
+;; This is required for some packages whose default branch isn't 'master' (which
+;; our package manager can't deal with; see radian-software/straight.el#279)
+;; (package! builtin-package :recipe (:branch "develop"))
+
+;; Use `:pin' to specify a particular commit to install.
+;; (package! builtin-package :pin "1a2b3c4d5e")
+
+
+;; Doom's packages are pinned to a specific commit and updated from release to
+;; release. The `unpin!' macro allows you to unpin single packages...
+;; (unpin! pinned-package)
+;; ...or multiple packages
+;; (unpin! pinned-package another-pinned-package)
+;; ...Or *all* packages (NOT RECOMMENDED; will likely break things)
+;; (unpin! t)

--- a/doom/packages.el
+++ b/doom/packages.el
@@ -44,6 +44,12 @@
 ;; Use `:pin' to specify a particular commit to install.
 ;; (package! builtin-package :pin "1a2b3c4d5e")
 
+;; Prettier Go test output
+(package! gotest)
+
+;; Icons in completion popup
+(package! kind-icon)
+
 
 ;; Doom's packages are pinned to a specific commit and updated from release to
 ;; release. The `unpin!' macro allows you to unpin single packages...

--- a/install.sh
+++ b/install.sh
@@ -240,6 +240,43 @@ install_fnm() {
   success "fnm installed — restart your shell then run: fnm install --lts"
 }
 
+# ── Emacs / Doom ─────────────────────────────────────────────────────────────
+install_doom() {
+  if ! has emacs; then
+    log "Installing Emacs..."
+    if is_mac; then
+      brew install --cask emacs
+    elif is_linux; then
+      pkg_install emacs
+    fi
+    success "Emacs installed"
+  else
+    success "Emacs already installed"
+  fi
+
+  if ! has git; then
+    error "git required for Doom install"
+    return 1
+  fi
+
+  if [ ! -d "$HOME/.emacs.d" ]; then
+    log "Installing Doom Emacs..."
+    git clone --depth 1 https://github.com/doomemacs/doomemacs "$HOME/.emacs.d"
+    "$HOME/.emacs.d/bin/doom" install --no-config
+    success "Doom Emacs installed"
+  else
+    success "Doom Emacs already installed"
+  fi
+
+  if ! has dlv; then
+    log "Installing delve (Go debugger)..."
+    go install github.com/go-delve/delve/cmd/dlv@latest
+    success "delve installed"
+  else
+    success "delve already installed"
+  fi
+}
+
 # ── Go ────────────────────────────────────────────────────────────────────────
 install_go() {
   if has go; then
@@ -341,6 +378,7 @@ setup_symlinks() {
   link "kitty"   "$CONFIG_DIR/kitty"
   link "yazi"    "$CONFIG_DIR/yazi"
   link ".zshrc"  "$HOME/.zshrc"
+  link "doom"    "$HOME/.doom.d"
 
   setup_kitty_os_keys
 }
@@ -382,6 +420,7 @@ usage() {
   echo "  --tmux         Tmux + TPM"
   echo "  --omzsh        Oh My Zsh + plugins + Powerlevel10k"
   echo "  --fnm          Node version manager"
+  echo "  --emacs        Doom Emacs + delve debugger"
   echo "  --go           Go language"
   echo "  --rust         Rust + Cargo"
   echo "  --fonts        JetBrainsMono Nerd Font"
@@ -410,6 +449,7 @@ main() {
         install_omzsh
         install_fnm
         install_go
+        install_doom
         install_fonts
         setup_symlinks
         setup_obsidian_vault
@@ -423,6 +463,7 @@ main() {
       --tmux)         install_tmux ;;
       --omzsh)        install_omzsh ;;
       --fnm)          install_fnm ;;
+      --emacs)        install_doom ;;
       --go)           install_go ;;
       --rust)         install_rust ;;
       --fonts)        install_fonts ;;

--- a/install.sh
+++ b/install.sh
@@ -241,18 +241,56 @@ install_fnm() {
 }
 
 # ── Emacs / Doom ─────────────────────────────────────────────────────────────
-install_doom() {
-  if ! has emacs; then
-    log "Installing Emacs..."
-    if is_mac; then
-      brew install --cask emacs
-    elif is_linux; then
+# Based on: https://github.com/doomemacs/doomemacs/blob/master/docs/getting_started.org
+install_emacs() {
+  if has emacs; then
+    success "Emacs already installed ($(emacs --version | head -1))"
+    return
+  fi
+
+  log "Installing Emacs..."
+  if is_mac; then
+    # emacs-plus with native compilation (recommended by Doom on macOS)
+    brew tap d12frosted/emacs-plus
+    brew install emacs-plus@30 --with-native-comp
+    # symlink Emacs.app to /Applications for GUI launching
+    local app_path="/opt/homebrew/opt/emacs-plus@30/Emacs.app"
+    [ -d "$app_path" ] && ln -sf "$app_path" /Applications/Emacs.app
+  elif is_linux; then
+    # Emacs 29+ on Debian/Ubuntu via PPA (kelleyk) for native-comp build
+    if has add-apt-repository; then
+      sudo add-apt-repository -y ppa:kelleyk/emacs || true
+      sudo apt-get update -qq
+      sudo apt-get install -y emacs29 || pkg_install emacs
+    else
       pkg_install emacs
     fi
-    success "Emacs installed"
-  else
-    success "Emacs already installed"
   fi
+  success "Emacs installed"
+}
+
+install_doom_deps() {
+  log "Installing Doom Emacs prerequisites (ripgrep, fd, git)..."
+  if is_mac; then
+    brew install ripgrep fd coreutils
+  elif is_linux; then
+    pkg_install ripgrep fd-find
+    if has fdfind && ! has fd; then
+      mkdir -p "$HOME/.local/bin"
+      ln -sf "$(which fdfind)" "$HOME/.local/bin/fd"
+    fi
+  fi
+  success "Doom prerequisites installed"
+}
+
+install_doom() {
+  if ! is_mac && ! is_linux; then
+    error "Unsupported OS — Doom install only supports macOS and Linux"
+    return 1
+  fi
+
+  install_emacs
+  install_doom_deps
 
   if ! has git; then
     error "git required for Doom install"
@@ -265,16 +303,24 @@ install_doom() {
     "$HOME/.emacs.d/bin/doom" install --no-config
     success "Doom Emacs installed"
   else
-    success "Doom Emacs already installed"
+    success "Doom Emacs already installed at ~/.emacs.d"
   fi
 
+  # delve for Go debugging
   if ! has dlv; then
-    log "Installing delve (Go debugger)..."
-    go install github.com/go-delve/delve/cmd/dlv@latest
-    success "delve installed"
+    if has go; then
+      log "Installing delve (Go debugger)..."
+      go install github.com/go-delve/delve/cmd/dlv@latest
+      success "delve installed"
+    else
+      warn "Go not found — skipping delve install (run --go first)"
+    fi
   else
     success "delve already installed"
   fi
+
+  warn "Add ~/.emacs.d/bin to PATH if not already:"
+  warn "  export PATH=\"\$HOME/.emacs.d/bin:\$PATH\""
 }
 
 # ── Go ────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Add `doom/` folder with Doom Emacs config (`init.el`, `config.el`, `packages.el`)
- Config includes Go LSP, debugger (dape + delve), test runner, and treemacs
- Add `install_doom()` to install Emacs, Doom Emacs, and delve Go debugger
- Symlink `~/.doom.d → dotfiles/doom/` via `setup_symlinks`
- Add `--emacs` flag to `install.sh`; included in `--all` flow

## Test plan

- [ ] `./install.sh --emacs` installs Emacs + Doom on fresh machine
- [ ] `./install.sh --symlinks` creates `~/.doom.d` → `dotfiles/doom/` symlink
- [ ] `doom sync` succeeds with config from symlinked folder