### PR TITLE
feat: chezmoi migration + doom config integration

### DIFF
--- a/dot_doom.d/README.md
+++ b/dot_doom.d/README.md
@@ -7,10 +7,7 @@ Multi-language development environment (Go primary) with eglot LSP, debugger, fo
 ### Emacs
 
 ```bash
-brew tap railwaycat/emacsmacport
-brew install emacs-mac@29 --with-xwidgets
-# cp not symlink — Spotlight does not index symlinks
-cp -r /opt/homebrew/opt/emacs-mac@29/Emacs.app /Applications/Emacs.app
+brew install emacs-plus --with-native-comp
 ```
 
 ### Doom sync
@@ -115,6 +112,12 @@ export SPOTIFY_CLIENT_SECRET="your_client_secret"
 | `SPC m d o` | Step out            |
 | `SPC m d l` | Restart last        |
 | `SPC m d q` | Quit                |
+
+### Go — Run (`SPC m r`)
+
+| Key         | Action         |
+| ----------- | -------------- |
+| `SPC m r r` | `go run` file  |
 
 ### Go — Tests (`SPC m t`)
 

--- a/dot_doom.d/README.md
+++ b/dot_doom.d/README.md
@@ -7,7 +7,10 @@ Multi-language development environment (Go primary) with eglot LSP, debugger, fo
 ### Emacs
 
 ```bash
-brew install emacs-plus --with-native-comp
+brew tap railwaycat/emacsmacport
+brew install emacs-mac@29 --with-xwidgets
+# cp not symlink — Spotlight does not index symlinks
+cp -r /opt/homebrew/opt/emacs-mac@29/Emacs.app /Applications/Emacs.app
 ```
 
 ### Doom sync

--- a/dot_doom.d/README.md
+++ b/dot_doom.d/README.md
@@ -1,0 +1,222 @@
+# Doom Emacs Config
+
+Multi-language development environment (Go primary) with eglot LSP, debugger, formatters, org-roam, Spotify, browser, HTTP client, and PostgreSQL browser.
+
+## Requirements
+
+### Emacs
+
+```bash
+brew install emacs-plus --with-native-comp
+```
+
+### Doom sync
+
+After cloning or modifying `init.el` / `packages.el`:
+
+```bash
+~/.config/emacs/bin/doom sync
+```
+
+Then restart Emacs.
+
+---
+
+### Go tools
+
+```bash
+go install golang.org/x/tools/gopls@latest            # LSP server
+go install mvdan.cc/gofumpt@latest                    # formatter (strict gofmt)
+go install github.com/go-delve/delve/cmd/dlv@latest   # debugger
+go install github.com/fatih/gomodifytags@latest       # struct tag editor (go-tag)
+go install github.com/josharian/impl@latest           # interface stub generator
+go install github.com/cweill/gotests/gotests@latest   # test stub generator
+go install golang.org/x/tools/cmd/goimports@latest    # import manager
+go install github.com/x-motemen/gore/cmd/gore@latest  # REPL
+go install golang.org/x/tools/cmd/godoc@latest        # documentation
+brew install golangci-lint                             # linter suite
+```
+
+### JavaScript
+
+```bash
+npm install -g typescript-language-server typescript
+```
+
+### Python
+
+```bash
+pip install pyright
+```
+
+### Rust
+
+```bash
+rustup component add rust-analyzer
+```
+
+### Spotify (smudge)
+
+Create an app at https://developer.spotify.com/dashboard, then set env vars:
+
+```bash
+export SPOTIFY_CLIENT_ID="your_client_id"
+export SPOTIFY_CLIENT_SECRET="your_client_secret"
+```
+
+---
+
+## Modules enabled
+
+| Module                  | Purpose                          |
+| ----------------------- | -------------------------------- |
+| `(lsp +eglot)`          | Eglot LSP client (fast, built-in)|
+| `(go +lsp)`             | Go + gopls                       |
+| `(javascript +lsp)`     | JS/TS + typescript-language-server |
+| `(python +lsp +pyright)`| Python + pyright                 |
+| `(rust +lsp)`           | Rust + rust-analyzer             |
+| `debugger`              | DAP / dape (Delve for Go)        |
+| `(format +onsave)`      | Apheleia async formatter         |
+| `tree-sitter`           | Tree-sitter syntax highlighting  |
+| `treemacs`              | File tree sidebar                |
+| `(org +roam2)`          | Org-roam zettelkasten            |
+| `data` / `yaml`         | JSON, TOML, YAML support         |
+| `eww`                   | Text browser (fallback)          |
+| `nav-flash`             | Cursor flash after jumps         |
+
+---
+
+## Keybindings
+
+### LSP / Eglot (`SPC c`)
+
+| Key       | Action              |
+| --------- | ------------------- |
+| `K`       | Hover doc (floating frame) |
+| `SPC c K` | Hover doc at point  |
+| `SPC c r` | Rename symbol       |
+| `SPC c a` | Code actions        |
+| `SPC c f` | Format buffer       |
+| `gd`      | Go to definition    |
+| `gr`      | Find references     |
+
+### Go — Debugger (`SPC m d`)
+
+| Key         | Action              |
+| ----------- | ------------------- |
+| `SPC m d d` | Start debug session |
+| `SPC m d b` | Toggle breakpoint   |
+| `SPC m d c` | Continue            |
+| `SPC m d n` | Next (step over)    |
+| `SPC m d i` | Step in             |
+| `SPC m d o` | Step out            |
+| `SPC m d l` | Restart last        |
+| `SPC m d q` | Quit                |
+
+### Go — Tests (`SPC m t`)
+
+| Key         | Action                  |
+| ----------- | ----------------------- |
+| `SPC m t t` | Test at point           |
+| `SPC m t f` | Test file               |
+| `SPC m t a` | Test all                |
+| `SPC m t r` | Test all + race detector|
+
+### Go — Tests pretty (`SPC m T`)
+
+| Key         | Action               |
+| ----------- | -------------------- |
+| `SPC m T t` | Test at point (gotest) |
+| `SPC m T f` | Test file            |
+| `SPC m T a` | Test project         |
+| `SPC m T b` | Benchmark            |
+| `SPC m T c` | Coverage             |
+
+### Go — Struct tags (`SPC m s`)
+
+| Key         | Action            |
+| ----------- | ----------------- |
+| `SPC m s a` | Add struct tag    |
+| `SPC m s r` | Remove struct tag |
+| `SPC m s c` | Clear all tags    |
+
+### File tree (`SPC o p`)
+
+| Key       | Action                     |
+| --------- | -------------------------- |
+| `SPC o p` | Toggle treemacs            |
+| `SPC o P` | Focus treemacs on file     |
+
+### Org-roam (`SPC n r`)
+
+| Key         | Action              |
+| ----------- | ------------------- |
+| `SPC n r f` | Find / create node  |
+| `SPC n r i` | Insert link         |
+| `SPC n r c` | Capture note        |
+| `SPC n r b` | Toggle backlinks    |
+| `SPC n r g` | Open graph view     |
+
+### Browser — xwidget-webkit (`SPC o w`)
+
+| Key         | Action              |
+| ----------- | ------------------- |
+| `SPC o w w` | Open URL            |
+| `SPC o w p` | Open URL at point   |
+| `SPC o w b` | Back                |
+| `SPC o w r` | Reload              |
+
+### Spotify (`SPC o S`)
+
+| Key           | Action          |
+| ------------- | --------------- |
+| `SPC o S s`   | Search tracks   |
+| `SPC o S l`   | My playlists    |
+| `SPC o S t`   | Toggle play     |
+| `SPC o S n`   | Next track      |
+| `SPC o S p`   | Previous track  |
+| `SPC o S =`   | Volume up       |
+| `SPC o S -`   | Volume down     |
+
+### HTTP client — verb (`C-c C-r` in org)
+
+Write requests in org files:
+
+```org
+* My API                                    :verb:
+** Get users
+get https://api.example.com/users
+
+** Create user
+post https://api.example.com/users
+Content-Type: application/json
+
+{
+  "name": "John"
+}
+```
+
+`C-c C-r s` — send request, `C-c C-r r` — show response.
+
+### PostgreSQL — pgmacs
+
+```
+M-x pgmacs-open-string
+```
+
+Connection string: `host=localhost port=5432 dbname=mydb user=postgres`
+
+---
+
+## Formatting
+
+On save via apheleia (async — no blocking `:w`):
+
+| Language   | Formatter             |
+| ---------- | --------------------- |
+| Go         | `gofumpt`             |
+| JS/TS      | `prettier` (if found) |
+| Python     | `black` (if found)    |
+| Rust       | `rustfmt`             |
+
+Manual format: `SPC c f`

--- a/dot_doom.d/config.el
+++ b/dot_doom.d/config.el
@@ -36,7 +36,7 @@
 
 ;; This determines the style of line numbers in effect. If set to `nil', line
 ;; numbers are disabled. For relative line numbers, set this to `relative'.
-(setq display-line-numbers-type t)
+(setq display-line-numbers-type 'relative)
 
 ;; If you use `org' and don't want your org files in the default location below,
 ;; change `org-directory'. It must be set before org loads!

--- a/dot_doom.d/config.el
+++ b/dot_doom.d/config.el
@@ -303,3 +303,140 @@
 ;;
 ;; You can also try 'gd' (or 'C-c c d') to jump to their definition and see how
 ;; they are implemented.
+
+;; (after! go-mode
+;;   (add-hook 'go-mode-hook #'gotest-ui-mode))
+
+;; ~/.doom.d/config.el
+(after! gotest-ui
+  (add-hook 'go-mode-hook #'gotest-ui-mode)
+
+  ;; Optional keybindings
+  (map! :after gotest-ui-mode
+        :map gotest-ui-mode-map
+        :localleader
+        :desc "Run Go tests" "t" #'gotest-ui-run
+        :desc "Toggle Go test UI" "u" #'gotest-ui-mode))
+
+;; go install golang.org/x/tools/gopls@latest
+;; go install github.com/fatih/gomodifytags@latest
+;; go install github.com/josharian/impl@latest
+;; go install github.com/go-delve/delve/cmd/dlv@latest
+;; go install github.com/rakyll/gotest@latest
+;; go install github.com/onsi/ginkgo/ginkgo@latest  # if using Ginkgo
+
+;; keep the cursor centered to avoid sudden scroll jumps
+(require 'centered-cursor-mode)
+
+;; disable in terminal modes
+;; http://stackoverflow.com/a/6849467/519736
+;; also disable in Info mode, because it breaks going back with the backspace key
+(define-global-minor-mode my-global-centered-cursor-mode centered-cursor-mode
+  (lambda ()
+    (when (not (memq major-mode
+                     (list 'Info-mode 'term-mode 'eshell-mode 'shell-mode 'erc-mode)))
+      (centered-cursor-mode))))
+(my-global-centered-cursor-mode 1)
+
+(use-package treesit
+  :mode (("\\.tsx\\'" . tsx-ts-mode)
+         ("\\.js\\'"  . typescript-ts-mode)
+         ("\\.mjs\\'" . typescript-ts-mode)
+         ("\\.mts\\'" . typescript-ts-mode)
+         ("\\.cjs\\'" . typescript-ts-mode)
+         ("\\.ts\\'"  . typescript-ts-mode)
+         ("\\.jsx\\'" . tsx-ts-mode)
+         ("\\.json\\'" .  json-ts-mode)
+         ("\\.Dockerfile\\'" . dockerfile-ts-mode)
+         ("\\.prisma\\'" . prisma-ts-mode)
+         ;; More modes defined here...
+         )
+  :preface
+  (defun os/setup-install-grammars ()
+    "Install Tree-sitter grammars if they are absent."
+    (interactive)
+    (dolist (grammar
+             '((css . ("https://github.com/tree-sitter/tree-sitter-css" "v0.20.0"))
+               (bash "https://github.com/tree-sitter/tree-sitter-bash")
+               (html . ("https://github.com/tree-sitter/tree-sitter-html" "v0.20.1"))
+               (javascript . ("https://github.com/tree-sitter/tree-sitter-javascript" "v0.21.2" "src"))
+               (json . ("https://github.com/tree-sitter/tree-sitter-json" "v0.20.2"))
+               (python . ("https://github.com/tree-sitter/tree-sitter-python" "v0.20.4"))
+               (go "https://github.com/tree-sitter/tree-sitter-go" "v0.20.0")
+               (markdown "https://github.com/ikatyang/tree-sitter-markdown")
+               (make "https://github.com/alemuller/tree-sitter-make")
+               (elisp "https://github.com/Wilfred/tree-sitter-elisp")
+               (cmake "https://github.com/uyha/tree-sitter-cmake")
+               (c "https://github.com/tree-sitter/tree-sitter-c")
+               (cpp "https://github.com/tree-sitter/tree-sitter-cpp")
+               (toml "https://github.com/tree-sitter/tree-sitter-toml")
+               (tsx . ("https://github.com/tree-sitter/tree-sitter-typescript" "v0.20.3" "tsx/src"))
+               (typescript . ("https://github.com/tree-sitter/tree-sitter-typescript" "v0.20.3" "typescript/src"))
+               (yaml . ("https://github.com/ikatyang/tree-sitter-yaml" "v0.5.0"))
+               (prisma "https://github.com/victorhqc/tree-sitter-prisma")))
+      (add-to-list 'treesit-language-source-alist grammar)
+      ;; Only install `grammar' if we don't already have it
+      ;; installed. However, if you want to *update* a grammar then
+      ;; this obviously prevents that from happening.
+      (unless (treesit-language-available-p (car grammar))
+        (treesit-install-language-grammar (car grammar)))))
+
+  ;; Optional, but recommended. Tree-sitter enabled major modes are
+  ;; distinct from their ordinary counterparts.
+  ;;
+  ;; You can remap major modes with `major-mode-remap-alist'. Note
+  ;; that this does *not* extend to hooks! Make sure you migrate them
+  ;; also
+  (dolist (mapping
+           '((python-mode . python-ts-mode)
+             (css-mode . css-ts-mode)
+             (typescript-mode . typescript-ts-mode)
+             (js-mode . typescript-ts-mode)
+             (js2-mode . typescript-ts-mode)
+             (c-mode . c-ts-mode)
+             (c++-mode . c++-ts-mode)
+             (c-or-c++-mode . c-or-c++-ts-mode)
+             (bash-mode . bash-ts-mode)
+             (css-mode . css-ts-mode)
+             (json-mode . json-ts-mode)
+             (js-json-mode . json-ts-mode)
+             (sh-mode . bash-ts-mode)
+             (sh-base-mode . bash-ts-mode)))
+    (add-to-list 'major-mode-remap-alist mapping))
+  :config
+  (os/setup-install-grammars))
+
+;; (use-package lsp-eslint
+;;   :demand t
+;;   :after lsp-mode)
+
+(after! lsp-mode
+  (setq lsp-gopls-staticcheck t
+        lsp-gopls-complete-unimported t
+        lsp-gopls-use-placeholders t))
+
+(after! go-mode
+  (add-hook 'before-save-hook #'lsp-format-buffer nil t)
+  (add-hook 'before-save-hook #'lsp-organize-imports nil t))
+
+
+(defun +go/run-gotest-ui ()
+  "Run gotest-ui in the project root."
+  (interactive)
+  (let ((default-directory (projectile-project-root)))
+    (ansi-term "gotest-ui ./..." "gotest-ui")
+    ;; After returning, restore highlighting
+    (add-hook 'term-exec-hook
+              (lambda (&rest _)
+                (dolist (buf (buffer-list))
+                  (with-current-buffer buf
+                    (when (eq major-mode 'go-mode)
+                      (font-lock-fontify-buffer)))))
+              nil 'local)))
+
+(defun +go/run-gotest-ui ()
+  "Run gotest-ui in vterm so it doesn't break syntax highlighting."
+  (interactive)
+  (let ((default-directory (projectile-project-root)))
+    (vterm)
+    (vterm-send-string "gotest-ui ./...\n")))

--- a/dot_doom.d/config.el
+++ b/dot_doom.d/config.el
@@ -132,9 +132,9 @@
 (defun +go/run ()
   "Run current Go file with go run."
   (interactive)
-  (compile (format "cd %s && go run %s"
-                   (+go/module-root)
-                   (buffer-file-name))))
+  (let ((dir (or (+go/module-root)
+                 (file-name-directory (buffer-file-name)))))
+    (compile (format "cd %s && go run %s" dir (buffer-file-name)))))
 
 (after! go-mode
   (map! :localleader

--- a/dot_doom.d/config.el
+++ b/dot_doom.d/config.el
@@ -42,58 +42,51 @@
 ;; change `org-directory'. It must be set before org loads!
 (setq org-directory "~/org/")
 
-;; Tune gopls (match nvim setup: inlay hints, codelenses, gofumpt, full analyses)
-(after! lsp-go
-  (setq lsp-go-analyses
-        '((unusedparams . t)
-          (unusedwrite . t)
-          (shadow . t)
-          (useany . t)
-          (nilness . t))
-        lsp-go-use-gofumpt t
-        lsp-go-codelenses
-        '((generate . t)
-          (gc_details . t)
-          (run_govulncheck . t)
-          (tidy . t)
-          (upgrade_dependency . t)
-          (vendor . t))
-        lsp-go-hints
-        '((assignVariableTypes . t)
-          (compositeLiteralFields . t)
-          (compositeLiteralTypes . t)
-          (constantValues . t)
-          (functionTypeParameters . t)
-          (parameterNames . t)
-          (rangeVariableTypes . t))))
+;; GC tuning — LSP servers produce large output; default limits cause stutters
+(setq gc-cons-threshold (* 100 1024 1024)
+      read-process-output-max (* 1024 1024))
 
-(after! lsp-mode
-  (setq lsp-inlay-hint-enable t
-        lsp-enable-snippet t
-        lsp-completion-enable-additional-text-edit t
-        lsp-signature-auto-activate t
-        lsp-signature-render-documentation t))
+;; Eglot: lighter LSP client, ~30% faster startup vs lsp-mode
+(after! eglot
+  (setq eglot-autoshutdown t
+        eglot-sync-connect nil        ; async connect, don't block startup
+        eglot-extend-to-xref t        ; xref jumps stay in eglot session
+        eglot-report-progress nil)    ; silence minibuffer noise
 
-;; Inline doc popup (like nvim's hover with K)
-(after! lsp-ui
-  (setq lsp-ui-doc-enable t
-        lsp-ui-doc-show-with-cursor nil   ; only on demand, not auto
-        lsp-ui-doc-show-with-mouse nil
-        lsp-ui-doc-position 'at-point
-        lsp-ui-doc-max-width 80
-        lsp-ui-doc-max-height 25
-        lsp-ui-doc-delay 0.2
-        lsp-ui-doc-include-signature t
-        lsp-ui-sideline-enable t
-        lsp-ui-sideline-show-hover nil
-        lsp-ui-sideline-show-diagnostics t
-        lsp-ui-sideline-show-code-actions t)
-  (map! :map lsp-mode-map
-        :n "K" #'lsp-ui-doc-glance
+  ;; gopls: same analyses/hints/lenses as previous lsp-go setup
+  (setq-default eglot-workspace-configuration
+    '(:gopls (:analyses     (:unusedparams t
+                             :unusedwrite  t
+                             :shadow       t
+                             :useany       t
+                             :nilness      t)
+              :gofumpt          t
+              :usePlaceholders  t
+              :directoryFilters ["-vendor" "-node_modules" "-.git"]
+              :codelenses (:generate         t
+                           :gc_details       t
+                           :run_govulncheck  t
+                           :tidy             t
+                           :upgrade_dependency t
+                           :vendor           t)
+              :hints (:assignVariableTypes    t
+                      :compositeLiteralFields t
+                      :compositeLiteralTypes  t
+                      :constantValues         t
+                      :functionTypeParameters t
+                      :parameterNames         t
+                      :rangeVariableTypes     t))))
+
+  (add-hook 'eglot-managed-mode-hook #'eglot-inlay-hints-mode)
+
+  ;; K = hover doc (replaces lsp-ui-doc-glance)
+  (map! :map eglot-mode-map
+        :n "K" #'eldoc-box-help-at-point
         :leader
         (:prefix ("c" . "code")
-         :desc "Toggle doc frame" "K" #'lsp-ui-doc-show
-         :desc "Focus doc frame"  "k" #'lsp-ui-doc-focus-frame)))
+         :desc "Hover doc"    "K" #'eglot-help-at-point
+         :desc "Rename"       "r" #'eglot-rename
+         :desc "Code actions" "a" #'eglot-code-actions)))
 
 ;; Go debugger (delve via dape) — split layout like nvim dap-ui
 (after! dape
@@ -152,7 +145,11 @@
          :desc "Test at point"  "t" #'+go/test-current-function
          :desc "Test file"      "f" #'+go/test-current-file
          :desc "Test all"       "a" #'+go/test-all
-         :desc "Test all+race"  "r" #'+go/test-all-race)))
+         :desc "Test all+race"  "r" #'+go/test-all-race)
+        (:prefix ("s" . "struct tags")
+         :desc "Add tag"        "a" #'go-tag-add
+         :desc "Remove tag"     "r" #'go-tag-remove
+         :desc "Clear tags"     "c" #'go-tag-clear)))
 
 
 ;; vterm
@@ -163,7 +160,7 @@
 (after! corfu
   (setq corfu-auto t
         corfu-auto-delay 0.1
-        corfu-auto-prefix 1
+        corfu-auto-prefix 2
         corfu-preselect 'first
         corfu-cycle t
         corfu-quit-no-match 'separator
@@ -186,12 +183,21 @@
   (add-to-list 'completion-at-point-functions #'cape-dabbrev)
   (add-to-list 'completion-at-point-functions #'cape-keyword))
 
+;; Format on save via apheleia (async subprocess — no LSP round-trip, no blocking :w)
+(after! apheleia
+  (setf (alist-get 'go-mode apheleia-mode-alist) 'gofumpt)
+  (setf (alist-get 'gofumpt apheleia-formatters) '("gofumpt")))
+
 ;; Projectile: auto-discover projects (like nvim-project depth=2 under ~/Documents)
 (after! projectile
   (setq projectile-project-search-path '(("~/Documents/" . 2))
         projectile-auto-discover t
         projectile-enable-caching t
         projectile-sort-order 'recently-active))
+
+;; golangci-lint as secondary flycheck checker (eglot/flymake is primary)
+(use-package! flycheck-golangci-lint
+  :hook (go-mode . flycheck-golangci-lint-setup))
 
 ;; Prettier Go test output via gotest
 (use-package! gotest
@@ -206,6 +212,56 @@
            :desc "Test project"   "a" #'go-test-current-project
            :desc "Benchmark"      "b" #'go-test-current-benchmark
            :desc "Coverage"       "c" #'go-test-current-coverage))))
+
+;; org-roam (Obsidian alternative — zettelkasten + backlinks)
+(after! org-roam
+  (setq org-roam-directory "~/org/roam/")
+  (org-roam-db-autosync-mode)
+  (map! :leader
+        (:prefix ("n r" . "roam")
+         :desc "Find node"     "f" #'org-roam-node-find
+         :desc "Insert link"   "i" #'org-roam-node-insert
+         :desc "Capture"       "c" #'org-roam-capture
+         :desc "Toggle buffer" "b" #'org-roam-buffer-toggle
+         :desc "Graph"         "g" #'org-roam-graph)))
+
+;; xwidget-webkit as default browser (real WebKit engine)
+(setq browse-url-browser-function #'xwidget-webkit-browse-url)
+(map! :leader
+      (:prefix ("o w" . "browser")
+       :desc "Browse URL"          "w" #'xwidget-webkit-browse-url
+       :desc "Browse URL at point" "p" (cmd! (xwidget-webkit-browse-url (thing-at-point 'url t)))
+       :desc "Back"                "b" #'xwidget-webkit-back
+       :desc "Reload"              "r" #'xwidget-webkit-reload))
+
+;; Smudge — Spotify controller (needs OAuth2 credentials)
+;; Get client-id/secret at https://developer.spotify.com/dashboard
+(use-package! smudge
+  :config
+  (setq smudge-oauth2-client-id     (getenv "SPOTIFY_CLIENT_ID")
+        smudge-oauth2-client-secret (getenv "SPOTIFY_CLIENT_SECRET")
+        smudge-transport 'connect))
+
+(after! smudge
+  (map! :leader
+        (:prefix ("o S" . "spotify")
+         :desc "Track search"  "s" #'smudge-track-search
+         :desc "My playlists"  "l" #'smudge-my-playlists
+         :desc "Toggle play"   "t" #'smudge-controller-toggle-play
+         :desc "Next"          "n" #'smudge-controller-next-track
+         :desc "Prev"          "p" #'smudge-controller-previous-track
+         :desc "Volume +"      "=" #'smudge-controller-volume-up
+         :desc "Volume -"      "-" #'smudge-controller-volume-down)))
+
+;; Verb — HTTP client in org-mode (Bruno/Postman alternative)
+(use-package! verb
+  :after org
+  :config
+  (define-key org-mode-map (kbd "C-c C-r") verb-command-map))
+
+;; pgmacs — PostgreSQL table browser (DBeaver alternative)
+(use-package! pgmacs
+  :commands (pgmacs-open-string pgmacs-open))
 
 ;; Whenever you reconfigure a package, make sure to wrap your config in an
 ;; `after!' block, otherwise Doom's defaults may override your settings. E.g.

--- a/dot_doom.d/config.el
+++ b/dot_doom.d/config.el
@@ -129,6 +129,13 @@
   (interactive)
   (compile (format "cd %s && go test -v -race ./..." (+go/module-root))))
 
+(defun +go/run ()
+  "Run current Go file with go run."
+  (interactive)
+  (compile (format "cd %s && go run %s"
+                   (+go/module-root)
+                   (buffer-file-name))))
+
 (after! go-mode
   (map! :localleader
         :map go-mode-map
@@ -141,11 +148,13 @@
          :desc "Step in"             "i" #'dape-step-in
          :desc "Step out"            "o" #'dape-step-out
          :desc "Quit"                "q" #'dape-quit)
+        (:prefix ("r" . "run")
+         :desc "Run file"       "r" #'+go/run)
         (:prefix ("t" . "test")
          :desc "Test at point"  "t" #'+go/test-current-function
          :desc "Test file"      "f" #'+go/test-current-file
          :desc "Test all"       "a" #'+go/test-all
-         :desc "Test all+race"  "r" #'+go/test-all-race)
+         :desc "Test all+race"  "R" #'+go/test-all-race)
         (:prefix ("s" . "struct tags")
          :desc "Add tag"        "a" #'go-tag-add
          :desc "Remove tag"     "r" #'go-tag-remove

--- a/dot_doom.d/init.el
+++ b/dot_doom.d/init.el
@@ -39,7 +39,7 @@
        ;;ligatures         ; ligatures and symbols to make your code pretty again
        ;;minimap           ; show a map of the code on the side
        modeline          ; snazzy, Atom-inspired modeline, plus API
-       ;;nav-flash         ; blink cursor line after big motions
+       nav-flash         ; blink cursor line after big motions
        ;;neotree           ; a project drawer, like NERDTree for vim
        ophints           ; highlight the region an operation acts on
        (popup +defaults)   ; tame sudden yet inevitable temporary windows
@@ -71,7 +71,7 @@
        :emacs
        dired             ; making dired pretty [functional]
        electric          ; smarter, keyword-based electric-indent
-       ;;eww               ; the internet is gross
+       eww               ; the internet is gross (text fallback + xwidget-webkit for real pages)
        ;;ibuffer           ; interactive buffer management
        tramp             ; remote files at your arthritic fingertips
        undo              ; persistent, smarter undo for your inevitable mistakes
@@ -100,8 +100,7 @@
        (eval +overlay)     ; run code, run (also, repls)
        lookup              ; navigate your code and its documentation
        ;;llm               ; when I said you needed friends, I didn't mean...
-       ;;(lsp +eglot)      ; M-x vscode
-       lsp
+       (lsp +eglot)        ; M-x vscode (eglot backend: lighter + faster)
        magit             ; a git porcelain for Emacs
        ;;make              ; run make tasks from Emacs
        ;;pass              ; password manager for nerds
@@ -125,7 +124,7 @@
        ;;coq               ; proofs-as-programs
        ;;crystal           ; ruby at the speed of c
        ;;csharp            ; unity, .NET, and mono shenanigans
-       ;;data              ; config/data formats
+       data              ; config/data formats
        ;;(dart +flutter)   ; paint ui and not much else
        ;;dhall
        ;;elixir            ; erlang done right
@@ -147,7 +146,7 @@
        ;;json              ; At least it ain't XML
        ;;janet             ; Fun fact: Janet is me!
        ;;(java +lsp)       ; the poster child for carpal tunnel syndrome
-       ;;javascript        ; all(hope(abandon(ye(who(enter(here))))))
+       (javascript +lsp)  ; all(hope(abandon(ye(who(enter(here))))))
        ;;julia             ; a better, faster MATLAB
        ;;kotlin            ; a better, slicker Java(Script)
        ;;latex             ; writing papers in Emacs has never been so fun
@@ -158,19 +157,19 @@
        ;;nim               ; python + lisp at the speed of c
        ;;nix               ; I hereby declare "nix geht mehr!"
        ;;ocaml             ; an objective camel
-       org               ; organize your plain life in plain text
+       (org +roam2)      ; organize your plain life in plain text
        ;;php               ; perl's insecure younger brother
        ;;plantuml          ; diagrams for confusing people more
        ;;graphviz          ; diagrams for confusing yourself even more
        ;;purescript        ; javascript, but functional
-       ;;python            ; beautiful is better than ugly
+       (python +lsp +pyright) ; beautiful is better than ugly
        ;;qt                ; the 'cutest' gui framework ever
        ;;racket            ; a DSL for DSLs
        ;;raku              ; the artist formerly known as perl6
        rest              ; Emacs as a REST client
        ;;rst               ; ReST in peace
        ;;(ruby +rails)     ; 1.step {|i| p "Ruby is #{i.even? ? 'love' : 'life'}"}
-       ;;(rust +lsp)       ; Fe2O3.unwrap().unwrap().unwrap().unwrap()
+       (rust +lsp)        ; Fe2O3.unwrap().unwrap().unwrap().unwrap()
        ;;scala             ; java, but good
        ;;(scheme +guile)   ; a fully conniving family of lisps
        sh                ; she sells {ba,z,fi}sh shells on the C xor
@@ -179,7 +178,7 @@
        ;;swift             ; who asked for emoji variables?
        ;;terra             ; Earth and Moon in alignment for performance.
        ;;web               ; the tubes
-       ;;yaml              ; JSON, but readable
+       yaml              ; JSON, but readable
        ;;zig               ; C, but simpler
 
        :email

--- a/dot_doom.d/packages.el
+++ b/dot_doom.d/packages.el
@@ -50,6 +50,25 @@
 ;; Icons in completion popup
 (package! kind-icon)
 
+;; Floating hover doc frame (replaces lsp-ui-doc-glance)
+(package! eldoc-box)
+
+;; Spotify controller
+(package! smudge)
+
+;; HTTP client (org-mode based, more powerful than restclient)
+(package! verb)
+
+;; PostgreSQL browser (DBeaver alternative)
+(package! pg)
+(package! pgmacs :recipe (:host github :repo "emarsden/pgmacs"))
+
+;; Go struct tag management (add/remove/rename json/db/etc tags)
+(package! go-tag)
+
+;; golangci-lint flycheck integration
+(package! flycheck-golangci-lint)
+
 
 ;; Doom's packages are pinned to a specific commit and updated from release to
 ;; release. The `unpin!' macro allows you to unpin single packages...

--- a/dot_doom.d/packages.el
+++ b/dot_doom.d/packages.el
@@ -77,3 +77,15 @@
 ;; (unpin! pinned-package another-pinned-package)
 ;; ...Or *all* packages (NOT RECOMMENDED; will likely break things)
 ;; (unpin! t)
+;; (load! "go")
+
+(package! dape)
+;; (package! gotest)
+
+;; (straight-use-package
+;;  `(gotest-ui-mode :type git :repo "https://github.com/antifuchs/gotest-ui-mode.git"))
+(package! gotest-ui
+  :recipe (:host github :repo "antifuchs/gotest-ui-mode"))
+
+(package! go-tag)
+(package! go-test)

--- a/run_once_install.sh.tmpl
+++ b/run_once_install.sh.tmpl
@@ -23,12 +23,13 @@ brew install --cask \
   ghostty \
   font-jetbrains-mono-nerd-font
 
-# Emacs (Doom)
+# Emacs (Doom) — emacs-mac with xwidgets for embedded browser support
 if ! has emacs; then
-  brew tap d12frosted/emacs-plus
-  brew install emacs-plus@30 --with-native-comp
-  app_path="/opt/homebrew/opt/emacs-plus@30/Emacs.app"
-  [ -d "$app_path" ] && ln -sf "$app_path" /Applications/Emacs.app
+  brew tap railwaycat/emacsmacport
+  brew install emacs-mac@29 --with-xwidgets
+  app_path="/opt/homebrew/opt/emacs-mac@29/Emacs.app"
+  # cp -r not ln -sf: Spotlight does not index symlinks
+  [ -d "$app_path" ] && cp -r "$app_path" /Applications/Emacs.app
 fi
 
 # fnm

--- a/run_once_install.sh.tmpl
+++ b/run_once_install.sh.tmpl
@@ -100,9 +100,12 @@ if ! has ghostty; then
   echo "[warn] Ghostty has no official Linux package — install manually: https://ghostty.org/download"
 fi
 
-# Emacs (Doom)
+# Emacs (Doom) — snap includes xwidgets (webkit); PPA fallback lacks it
 if ! has emacs; then
-  if has add-apt-repository; then
+  if has snap; then
+    sudo snap install emacs --classic
+  elif has add-apt-repository; then
+    sudo apt-get install -y libwebkit2gtk-4.1-0 libwebkit2gtk-4.0-0 2>/dev/null || true
     sudo add-apt-repository -y ppa:kelleyk/emacs || true
     sudo apt-get update -qq
     sudo apt-get install -y emacs29 || sudo apt-get install -y emacs


### PR DESCRIPTION
## Summary

- Migrate all dotfiles to chezmoi management (tmux, zsh, p10k, wezterm, aerospace, yazi)
- Integrate Doom Emacs config into chezmoi (`dot_doom.d/`) — single source of truth
- Add tmux plugins, go-layout script, QoL settings
- Fix chezmoi sourceDir, externals, permissions
- Sync latest doom config: eglot migration, GC tuning, go-tag, eldoc-box, smudge, verb, pgmacs, flycheck-golangci-lint, relative line numbers

## After merge on new machine

```bash
sh -c "$(curl -fsLS get.chezmoi.io)" -- init --apply Victorinolavida
~/.emacs.d/bin/doom sync
```