### PR TITLE
fix(install): fix OMZ detection, add direnv and IntelliOne Nerd Font

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,51 @@ chezmoi init --apply Victorinolavida
 
 [chezmoi](https://chezmoi.io) manages symlinks and file application. On first run it also executes `run_once_install.sh.tmpl` to install all packages.
 
+---
+
+## `run_once_install.sh.tmpl`
+
+This script runs automatically when you first apply the dotfiles (or whenever its content changes). It bootstraps your environment end-to-end.
+
+### What it installs
+
+**macOS** (via Homebrew)
+- CLI tools: `git`, `curl`, `zsh`, `eza`, `bat`, `fzf`, `fd`, `zoxide`, `lazygit`, `tmux`, `ripgrep`, `go`, `neovim`, `yazi`
+- Casks: `ghostty`, `font-jetbrains-mono-nerd-font`, `font-intone-mono-nerd-font`
+- Emacs: `emacs-mac@29` (railwaycat tap, with xwidgets + native compilation)
+- Node version manager: `fnm`
+
+**Linux** (via apt + GitHub releases)
+- apt: `git`, `curl`, `zsh`, `tmux`, `ripgrep`, `build-essential`, `fzf`, `fd-find`, `zoxide`, `golang-go`
+- `eza` via the official gierens apt repo
+- `bat` (with a `bat` → `batcat` symlink on Ubuntu)
+- `lazygit`, `yazi` — downloaded from GitHub releases
+- `neovim` via snap
+- `ghostty` — prints a manual-install reminder (no official Linux package)
+- Emacs: snap (preferred) or kelleyk PPA
+- `fnm`, Rust/Cargo, JetBrainsMono Nerd Font
+
+**Both platforms**
+- Oh My Zsh
+- Tmux Plugin Manager (TPM) → `~/.tmux/plugins/tpm`
+- Doom Emacs → `~/.emacs.d`
+- `dlv` (Go debugger, via `go install`)
+
+### When it runs
+
+chezmoi tracks a hash of the script. It runs automatically on:
+- `chezmoi init --apply` (first-time setup)
+- `chezmoi apply` / `chezmoi update` — only if the script content has changed since the last run
+
+### Force re-run
+
+To re-run the script without changing its content:
+
+```bash
+chezmoi state delete-bucket --bucket=scriptState
+chezmoi apply
+```
+
 | Command | What it does |
 |---------|-------------|
 | `chezmoi apply` | Apply config changes to `$HOME` |
@@ -72,12 +117,45 @@ Requires TPM. Installed by `run_once_install.sh.tmpl`. After first apply, open t
 Config sourced from [minimal_nvim](https://github.com/Victorinolavida/minimal_nvim) via `.chezmoiexternal.toml`. chezmoi clones it automatically to `~/.config/nvim`.
 
 ### Doom Emacs
-Config at `~/.doom.d/`. Doom itself installed by `run_once_install.sh.tmpl`.
+Config at `~/.config/doom/` (managed by chezmoi). Doom itself cloned to `~/.emacs.d` by `run_once_install.sh.tmpl`.
 
 Add `~/.emacs.d/bin` to `PATH` if not already present (`.zshrc` handles this).
 
 ### Yazi
 Modern terminal file manager. Use `ya` instead of `yazi` to `cd` into the last visited directory on exit.
+
+---
+
+## Troubleshooting
+
+### OMZ plugins/theme not found after fresh install
+
+chezmoi creates `~/.oh-my-zsh/custom/` (for plugins) *before* the install script runs, which can cause the OMZ installer to be skipped if the check tests the directory rather than the actual install. The script now checks for `oh-my-zsh.sh` instead.
+
+If you still see `plugin not found` or `theme not found` errors, force-refresh the external repos:
+
+```bash
+chezmoi apply --force --refresh-externals=always
+```
+
+### oh-my-zsh.sh not found
+
+OMZ wasn't installed. Remove the partial directory and re-run:
+
+```bash
+rm -rf ~/.oh-my-zsh
+bash <(chezmoi execute-template < ~/.local/share/chezmoi/run_once_install.sh.tmpl)
+chezmoi apply --force --refresh-externals=always
+```
+
+### direnv: command not found
+
+`direnv` is installed by the run_once script. If it's missing, install manually:
+
+```bash
+brew install direnv        # macOS
+sudo apt-get install direnv  # Linux
+```
 
 ---
 

--- a/run_once_install.sh.tmpl
+++ b/run_once_install.sh.tmpl
@@ -17,11 +17,13 @@ brew install \
   ripgrep \
   go \
   neovim \
-  yazi
+  yazi \
+  direnv
 
 brew install --cask \
   ghostty \
-  font-jetbrains-mono-nerd-font
+  font-jetbrains-mono-nerd-font \
+  font-intone-mono-nerd-font
 
 # Emacs (Doom) — emacs-mac with xwidgets for embedded browser support
 if ! has emacs; then
@@ -61,7 +63,7 @@ if ! has bat && ! has batcat; then
   fi
 fi
 
-sudo apt-get install -y fzf fd-find zoxide golang-go
+sudo apt-get install -y fzf fd-find zoxide golang-go direnv
 
 if has fdfind && ! has fd; then
   mkdir -p "$HOME/.local/bin"
@@ -139,10 +141,23 @@ if ! fc-list | grep -qi "JetBrainsMono Nerd Font"; then
   fc-cache -fv "$font_dir"
 fi
 
+# IntelliOne Mono Nerd Font
+if ! fc-list | grep -qi "IntelliOne Mono"; then
+  font_dir="$HOME/.local/share/fonts/IntoneMonoNerdFont"
+  version=$(curl -s "https://api.github.com/repos/ryanoasis/nerd-fonts/releases/latest" \
+    | grep '"tag_name"' | sed 's/.*"\(v[^"]*\)".*/\1/')
+  curl -Lo /tmp/IntelliOneMono.zip \
+    "https://github.com/ryanoasis/nerd-fonts/releases/download/${version}/IntelliOneMono.zip"
+  mkdir -p "$font_dir"
+  unzip -o /tmp/IntelliOneMono.zip -d "$font_dir"
+  rm /tmp/IntelliOneMono.zip
+  fc-cache -fv "$font_dir"
+fi
+
 {{ end -}}
 
 # ── Oh My Zsh (all platforms) ─────────────────────────────────────────────────
-if [ ! -d "$HOME/.oh-my-zsh" ]; then
+if [ ! -f "$HOME/.oh-my-zsh/oh-my-zsh.sh" ]; then
   sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended
 fi
 


### PR DESCRIPTION
- Check for oh-my-zsh.sh instead of directory to avoid chezmoi externals creating ~/.oh-my-zsh/custom/ before OMZ installs
- Add direnv to macOS and Linux install lists
- Add font-intone-mono-nerd-font cask (macOS) and GitHub releases download (Linux)
- Add troubleshooting section to README covering OMZ plugin errors, missing oh-my-zsh.sh, and direnv not found