### PR TITLE
feat: gitconfig template, theme fixes, fnm via brew

### DIFF
--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -1,5 +1,13 @@
 sourceDir = "{{ .chezmoi.sourceDir }}"
 
 [data]
+  is_work = {{ promptBool "Is this a work machine?" }}
+{{- if promptBool "Is this a work machine?" }}
+  name = {{ promptString "Full name" | quote }}
+  email = {{ promptString "Work email" | quote }}
+  github_user = {{ promptString "GitHub username" | quote }}
+{{- else }}
   name = "Victorino Lavida"
-  email = "viclavida@gmail.com"
+  email = "victorino.lavida@gmail.com"
+  github_user = "Victorinolavida"
+{{- end }}

--- a/dot_config/ghostty/config
+++ b/dot_config/ghostty/config
@@ -3,7 +3,7 @@
 # --- appearance ---
 font-family = JetBrainsMono Nerd Font
 font-size = 16
-theme = catppuccin-mocha
+theme = Catppuccin Mocha
 background-opacity = 1.0
 cursor-style = block
 cursor-style-blink = false

--- a/dot_gitconfig.tmpl
+++ b/dot_gitconfig.tmpl
@@ -1,0 +1,7 @@
+[user]
+	name = {{ .name }}
+	email = {{ .email }}
+	username = {{ .github_user }}
+
+[github]
+	user = {{ .github_user }}

--- a/dot_tmux.conf
+++ b/dot_tmux.conf
@@ -122,6 +122,7 @@ set -g pane-border-format "#{?pane_active,#[fg=#{@thm_lavender} bold] ● #[fg=#
 # ============================================================================
 # THEME - CATPPUCCIN
 # ============================================================================
+set -g @plugin 'catppuccin/tmux'
 set -g @catppuccin_flavor 'mocha'
 set -g @catppuccin_window_status_style "rounded"
 

--- a/dot_zshrc
+++ b/dot_zshrc
@@ -105,3 +105,9 @@ function ya() {
   rm -f -- "$tmp"
 }
 eval "$(direnv hook zsh)"
+
+# fnm
+FNM_PATH="/opt/homebrew/opt/fnm/bin"
+if [ -d "$FNM_PATH" ]; then
+  eval "$(fnm env --shell zsh)"
+fi

--- a/run_once_install.sh.tmpl
+++ b/run_once_install.sh.tmpl
@@ -18,7 +18,8 @@ brew install \
   go \
   neovim \
   yazi \
-  direnv
+  direnv \
+  fnm
 
 brew install --cask \
   ghostty \
@@ -32,11 +33,6 @@ if ! has emacs; then
   app_path="/opt/homebrew/opt/emacs-mac@29/Emacs.app"
   # cp -r not ln -sf: Spotlight does not index symlinks
   [ -d "$app_path" ] && cp -r "$app_path" /Applications/Emacs.app
-fi
-
-# fnm
-if ! has fnm; then
-  curl -fsSL https://fnm.vercel.app/install | bash
 fi
 
 {{ else if eq .chezmoi.os "linux" -}}


### PR DESCRIPTION
## Summary
- Add `dot_gitconfig.tmpl` with work/personal machine support (init prompts for machine type)
- Fix Ghostty theme name to `Catppuccin Mocha` (was `catppuccin-mocha`, which failed to resolve)
- Declare `catppuccin/tmux` via `@plugin` so TPM actually installs it (was `run` but never cloned)
- Install fnm via Homebrew on macOS and add fnm env init to `.zshrc`

## Test plan
- Ghostty loads the theme with no "theme not found" error
- tmux: `prefix + I` installs catppuccin, status bar renders
- `fnm` available after `brew install` / new shell