### PR TITLE
fix(chezmoi): ask work-machine prompt once with y/n hint

### DIFF
--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -1,8 +1,10 @@
 sourceDir = "{{ .chezmoi.sourceDir }}"
 
+{{- $isWork := promptBool "Is this a work machine? (y/n)" }}
+
 [data]
-  is_work = {{ promptBool "Is this a work machine?" }}
-{{- if promptBool "Is this a work machine?" }}
+  is_work = {{ $isWork }}
+{{- if $isWork }}
   name = {{ promptString "Full name" | quote }}
   email = {{ promptString "Work email" | quote }}
   github_user = {{ promptString "GitHub username" | quote }}


### PR DESCRIPTION
## Summary
- `promptBool "Is this a work machine?"` was called twice, so `chezmoi init` asked the question two times. Capture it once into `$isWork`.
- Label the prompt `(y/n)` so it's clear y or n is expected.

## Test plan
- `chezmoi init` prompts the work-machine question exactly once