### PR TITLE
fix(doom): restore lost merge blocks, add symbol font, drop Spotify

### DIFF
--- a/dot_config/doom/README.md
+++ b/dot_config/doom/README.md
@@ -1,6 +1,6 @@
 # Doom Emacs Config
 
-Multi-language development environment (Go primary) with eglot LSP, debugger, formatters, org-roam, Spotify, browser, HTTP client, and PostgreSQL browser.
+Multi-language development environment (Go primary) with eglot LSP, debugger, formatters, org-roam, browser, HTTP client, and PostgreSQL browser.
 
 ## Requirements
 
@@ -56,15 +56,6 @@ pip install pyright
 
 ```bash
 rustup component add rust-analyzer
-```
-
-### Spotify (smudge)
-
-Create an app at https://developer.spotify.com/dashboard, then set env vars:
-
-```bash
-export SPOTIFY_CLIENT_ID="your_client_id"
-export SPOTIFY_CLIENT_SECRET="your_client_secret"
 ```
 
 ---
@@ -174,18 +165,6 @@ export SPOTIFY_CLIENT_SECRET="your_client_secret"
 | `SPC o w p` | Open URL at point   |
 | `SPC o w b` | Back                |
 | `SPC o w r` | Reload              |
-
-### Spotify (`SPC o S`)
-
-| Key           | Action          |
-| ------------- | --------------- |
-| `SPC o S s`   | Search tracks   |
-| `SPC o S l`   | My playlists    |
-| `SPC o S t`   | Toggle play     |
-| `SPC o S n`   | Next track      |
-| `SPC o S p`   | Previous track  |
-| `SPC o S =`   | Volume up       |
-| `SPC o S -`   | Volume down     |
 
 ### HTTP client — verb (`C-c C-r` in org)
 

--- a/dot_config/doom/config.el
+++ b/dot_config/doom/config.el
@@ -115,6 +115,22 @@
          :desc "Rename"       "r" #'eglot-rename
          :desc "Code actions" "a" #'eglot-code-actions)))
 
+;; Speed up eglot by routing LSP JSON through the emacs-lsp-booster binary.
+;; Requires the `emacs-lsp-booster' executable on PATH (cargo install
+;; emacs-lsp-booster). Falls back gracefully (logs a warning) if missing.
+(use-package! eglot-booster
+  :after eglot
+  :config (eglot-booster-mode))
+
+;; Fuzzy workspace-symbol jump across the whole project (SPC c j).
+(use-package! consult-eglot
+  :after eglot
+  :init
+  (map! :map eglot-mode-map
+        :leader
+        (:prefix ("c" . "code")
+         :desc "Workspace symbols" "j" #'consult-eglot-symbols)))
+
 ;; Load dape on the first opened file. `dape-breakpoint-global-mode' is the
 ;; one autoloaded entry point that pulls in the whole dape feature, so this
 ;; both defines every `dape-*' command (no "commandp" errors from the SPC d

--- a/dot_config/doom/config.el
+++ b/dot_config/doom/config.el
@@ -31,8 +31,11 @@
 
 ;; IntelliOne Mono Nerd Font (installed via run_once_install.sh).
 ;; macOS registers the monospace variant as "IntoneMono NFM".
-(setq doom-font     (font-spec :family "IntoneMono NFM" :size 14)
-      doom-big-font (font-spec :family "IntoneMono NFM" :size 20))
+;; `doom-symbol-font' points at the Symbols Nerd Font (also installed by the
+;; script) so glyphs/icons used by nerd-icons render correctly.
+(setq doom-font        (font-spec :family "IntoneMono NFM" :size 14)
+      doom-big-font    (font-spec :family "IntoneMono NFM" :size 20)
+      doom-symbol-font (font-spec :family "Symbols Nerd Font Mono"))
 
 ;; There are two ways to load a theme. Both assume the theme is installed and
 ;; available. You can either set `doom-theme' or manually load a theme with the
@@ -383,25 +386,6 @@
        :desc "Browse URL at point" "p" (cmd! (xwidget-webkit-browse-url (thing-at-point 'url t)))
        :desc "Back"                "b" #'xwidget-webkit-back
        :desc "Reload"              "r" #'xwidget-webkit-reload))
-
-;; Smudge — Spotify controller (needs OAuth2 credentials)
-;; Get client-id/secret at https://developer.spotify.com/dashboard
-(use-package! smudge
-  :config
-  (setq smudge-oauth2-client-id     (getenv "SPOTIFY_CLIENT_ID")
-        smudge-oauth2-client-secret (getenv "SPOTIFY_CLIENT_SECRET")
-        smudge-transport 'connect))
-
-(after! smudge
-  (map! :leader
-        (:prefix ("o S" . "spotify")
-         :desc "Track search"  "s" #'smudge-track-search
-         :desc "My playlists"  "l" #'smudge-my-playlists
-         :desc "Toggle play"   "t" #'smudge-controller-toggle-play
-         :desc "Next"          "n" #'smudge-controller-next-track
-         :desc "Prev"          "p" #'smudge-controller-previous-track
-         :desc "Volume +"      "=" #'smudge-controller-volume-up
-         :desc "Volume -"      "-" #'smudge-controller-volume-down)))
 
 ;; Verb — HTTP client in org-mode (Bruno/Postman alternative)
 (use-package! verb

--- a/dot_config/doom/packages.el
+++ b/dot_config/doom/packages.el
@@ -61,9 +61,6 @@
 ;; Fuzzy workspace-symbol search across the whole project via eglot + consult
 (package! consult-eglot)
 
-;; Spotify controller
-(package! smudge)
-
 ;; HTTP client (org-mode based, more powerful than restclient)
 (package! verb)
 

--- a/dot_config/doom/packages.el
+++ b/dot_config/doom/packages.el
@@ -58,6 +58,9 @@
 (package! eglot-booster
   :recipe (:host github :repo "jdtsmith/eglot-booster"))
 
+;; Fuzzy workspace-symbol search across the whole project via eglot + consult
+(package! consult-eglot)
+
 ;; Spotify controller
 (package! smudge)
 


### PR DESCRIPTION
Cleanup PR off `main`, bundled into one branch to avoid the overlapping-PR
merge conflicts that dropped code in #25/#26.

## Restore (lost in the #25/#26 merge)
- **eglot-booster**: was in `packages.el` but its `(eglot-booster-mode)`
  activation block was lost — restored so the booster is actually on.
- **consult-eglot**: was missing from both `packages.el` and `config.el` —
  restored the package + `SPC c j` workspace-symbols binding.

## Nerd font
- Set `doom-symbol-font` to "Symbols Nerd Font Mono" (already installed by
  `run_once_install.sh`) so nerd-icons glyphs render correctly.

## Remove Spotify (smudge)
- Drop the smudge package, its `use-package!`/`after!` config, the
  `SPC o S` keybindings, and the README sections.

Needs `doom sync` + restart after merge (consult-eglot is a new package;
smudge is removed).