### PR TITLE
feat(doom): add modules + go codegen; fix chezmoi install --source

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,16 @@ Personal dotfiles for macOS and Linux. Managed with [chezmoi](https://chezmoi.io
 ## Quick Install
 
 ```bash
-sh -c "$(curl -fsLS get.chezmoi.io)" -- init --apply Victorinolavida
+sh -c "$(curl -fsLS get.chezmoi.io)" -- init --apply --source ~/.config/dotfiles Victorinolavida
 ```
 
 Or if chezmoi is already installed:
 
 ```bash
-chezmoi init --apply Victorinolavida
+chezmoi init --apply --source ~/.config/dotfiles Victorinolavida
 ```
+
+> **Note:** `--source ~/.config/dotfiles` is required. This repo sets `sourceDir = ~/.config/dotfiles` in `.chezmoi.toml.tmpl`, so chezmoi must clone there too. Without `--source`, chezmoi clones to its default (`~/.local/share/chezmoi`), which won't match `sourceDir` — and your dotfiles will look unmanaged.
 
 ---
 

--- a/dot_config/doom/README.md
+++ b/dot_config/doom/README.md
@@ -56,7 +56,33 @@ pip install pyright
 
 ```bash
 rustup component add rust-analyzer
+rustup component add clippy        # rust-analyzer runs clippy for diagnostics
 ```
+
+### YAML / docker-compose / Kubernetes manifests
+
+```bash
+npm install -g yaml-language-server
+```
+
+Schemas are pulled automatically from SchemaStore (GitHub Actions,
+docker-compose, etc.). For Kubernetes manifests, add a modeline at the top of
+the file so the server validates against the right schema:
+
+```yaml
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.30.0-standalone-strict/deployment.json
+```
+
+### Docker
+
+```bash
+npm install -g dockerfile-language-server-nodejs   # docker-langserver
+```
+
+### Kubernetes (cluster UI)
+
+`SPC o k k` opens a magit-style overview of the cluster in the current
+`kubectl` context. Requires `kubectl` on `PATH`.
 
 ---
 
@@ -69,6 +95,9 @@ rustup component add rust-analyzer
 | `(javascript +lsp)`     | JS/TS + typescript-language-server |
 | `(python +lsp +pyright)`| Python + pyright                 |
 | `(rust +lsp)`           | Rust + rust-analyzer             |
+| `(yaml +lsp)`           | YAML + yaml-language-server      |
+| `(docker +lsp)`         | Dockerfile + docker-langserver   |
+| `kubernetes`            | Cluster overview UI (`SPC o k k`)|
 | `debugger`              | DAP / dape (Delve for Go)        |
 | `(format +onsave)`      | Apheleia async formatter         |
 | `tree-sitter`           | Tree-sitter syntax highlighting  |
@@ -139,6 +168,26 @@ rustup component add rust-analyzer
 | `SPC m s a` | Add struct tag    |
 | `SPC m s r` | Remove struct tag |
 | `SPC m s c` | Clear all tags    |
+
+### Rust — Cargo (`SPC m b` / `SPC m t`)
+
+Provided by the `rust` module (rustic):
+
+| Key         | Action         |
+| ----------- | -------------- |
+| `SPC m b b` | cargo build    |
+| `SPC m b c` | cargo check    |
+| `SPC m b C` | cargo clippy   |
+| `SPC m b r` | cargo run      |
+| `SPC m b f` | cargo fmt      |
+| `SPC m t a` | cargo test all |
+| `SPC m t t` | test at point  |
+
+### Kubernetes (`SPC o k`)
+
+| Key         | Action                  |
+| ----------- | ----------------------- |
+| `SPC o k k` | Cluster overview        |
 
 ### File tree (`SPC o p`)
 

--- a/dot_config/doom/config.el
+++ b/dot_config/doom/config.el
@@ -94,7 +94,28 @@
                       :constantValues         t
                       :functionTypeParameters t
                       :parameterNames         t
-                      :rangeVariableTypes     t))))
+                      :rangeVariableTypes     t))
+      ;; rust-analyzer: clippy for diagnostics, all features, proc-macro
+      ;; expansion, and a rich set of inlay hints (rendered by
+      ;; eglot-inlay-hints-mode, enabled in the managed-mode-hook above).
+      :rust-analyzer (:check (:command "clippy")
+                      :cargo (:buildScripts (:enable t)
+                              :features "all")
+                      :procMacro (:enable t)
+                      :inlayHints (:bindingModeHints      (:enable t)
+                                   :closureReturnTypeHints (:enable "always")
+                                   :lifetimeElisionHints   (:enable "always"
+                                                            :useParameterNames t)))
+      ;; yaml-language-server: validation, hover, completion, and automatic
+      ;; schema association from SchemaStore (GitHub Actions, docker-compose,
+      ;; etc.). For Kubernetes manifests add a modeline at the top of the file:
+      ;;   # yaml-language-server: $schema=<url-to-k8s-schema>
+      ;; or use the kubernetes-json-schema URLs per resource kind.
+      :yaml (:format       (:enable t)
+             :validate     t
+             :hover        t
+             :completion   t
+             :schemaStore  (:enable t))))
 
   (add-hook 'eglot-managed-mode-hook #'eglot-inlay-hints-mode)
 
@@ -133,6 +154,33 @@
         :leader
         (:prefix ("c" . "code")
          :desc "Workspace symbols" "j" #'consult-eglot-symbols)))
+
+;; docker-compose-mode — compose files get yaml-language-server (schema from
+;; SchemaStore) just like plain YAML. docker-compose-mode derives from
+;; yaml-mode but Doom runs the *exact* major-mode's local-vars-hook, so wire
+;; eglot up explicitly here.
+(use-package! docker-compose-mode
+  :defer t
+  :config
+  (after! eglot
+    (add-to-list 'eglot-server-programs
+                 '(docker-compose-mode . ("yaml-language-server" "--stdio"))))
+  (add-hook 'docker-compose-mode-local-vars-hook #'lsp! 'append))
+
+;; Kubernetes — magit-style cluster overview (SPC o k k). Refresh is on demand
+;; rather than on a timer so it doesn't hammer the cluster in the background.
+(use-package! kubernetes
+  :commands (kubernetes-overview)
+  :init
+  (map! :leader
+        (:prefix ("o" . "open")
+         (:prefix ("k" . "kubernetes")
+          :desc "Overview" "k" #'kubernetes-overview)))
+  :config
+  (setq kubernetes-poll-frequency 3600
+        kubernetes-redraw-frequency 3600))
+
+(use-package! kubernetes-evil :after kubernetes)
 
 ;; Load dape on the first opened file. `dape-breakpoint-global-mode' is the
 ;; one autoloaded entry point that pulls in the whole dape feature, so this
@@ -221,7 +269,28 @@
                  :type "go"
                  :mode "test"
                  :cwd "."
-                 :program ".")))
+                 :program "."))
+
+  ;; Debug only the single test function under point (delve via DAP). Same as
+  ;; `go-debug-test' but passes `-test.run ^TestName$' so just that test runs.
+  ;; Reachable from the `SPC d d' config picker, like the other go-debug-* configs.
+  (add-to-list 'dape-configs
+               '(go-debug-test-at-point
+                 modes (go-mode go-ts-mode)
+                 ensure dape-ensure-command
+                 command "dlv"
+                 command-args ("dap" "--listen" "127.0.0.1::autoport")
+                 command-cwd dape-command-cwd
+                 port :autoport
+                 :request "launch"
+                 :type "go"
+                 :mode "test"
+                 :cwd "."
+                 :program "."
+                 :args (lambda ()
+                         (if-let ((name (+go/test-name-at-point)))
+                             (vector "-test.run" (format "^%s$" name))
+                           (user-error "No Go test function at point"))))))
 
 ;; Go test runner (go.work workspace aware)
 (defun +go/module-root ()
@@ -237,6 +306,10 @@
                      (concat "./" (file-relative-name
                                    (file-name-directory (buffer-file-name))
                                    mod-root))))))
+
+(defun +go/test-name-at-point ()
+  "Name of the Go test function surrounding point, or nil."
+  (which-function))
 
 (defun +go/test-current-function ()
   "Run test function at point."
@@ -300,7 +373,12 @@
         (:prefix ("s" . "struct tags")
          :desc "Add tag"        "a" #'go-tag-add
          :desc "Remove tag"     "r" #'go-tag-remove
-         :desc "Clear tags"     "c" #'go-tag-clear)))
+         :desc "Clear tags"     "c" #'go-tag-clear)
+        ;; Code generation. `go-impl' needs the `impl' binary and
+        ;; `go-fill-struct' needs `fillstruct' on PATH (see install notes below).
+        (:prefix ("i" . "implement/fill")
+         :desc "Impl interface" "i" #'go-impl
+         :desc "Fill struct"    "f" #'go-fill-struct)))
 
 
 ;; vterm
@@ -317,16 +395,9 @@
         corfu-quit-no-match 'separator
         corfu-preview-current 'insert
         corfu-popupinfo-delay '(0.3 . 0.2))
-  (corfu-popupinfo-mode 1)
-  (with-eval-after-load 'kind-icon
-    (setq kind-icon-default-face 'corfu-default)
-    (add-to-list 'corfu-margin-formatters #'kind-icon-margin-formatter)))
-
-(use-package! kind-icon
-  :after corfu
-  :config
-  (setq kind-icon-use-icons t
-        kind-icon-blend-background nil))
+  (corfu-popupinfo-mode 1))
+;; Completion icons are provided by the corfu `+icons' module flag
+;; (nerd-icons-corfu), so no manual kind-icon setup is needed here.
 
 ;; Cape: extra completion sources
 (after! cape
@@ -345,10 +416,6 @@
         projectile-auto-discover t
         projectile-enable-caching t
         projectile-sort-order 'recently-active))
-
-;; golangci-lint as secondary flycheck checker (eglot/flymake is primary)
-(use-package! flycheck-golangci-lint
-  :hook (go-mode . flycheck-golangci-lint-setup))
 
 ;; Prettier Go test output via gotest
 (use-package! gotest

--- a/dot_config/doom/init.el
+++ b/dot_config/doom/init.el
@@ -22,7 +22,7 @@
 
        :completion
        ;;company           ; the ultimate code completion backend
-       (corfu +orderless)  ; complete with cap(f), cape and a flying feather!
+       (corfu +orderless +icons)  ; complete with cap(f), cape and a flying feather!
        ;;helm              ; the *other* search engine for love and life
        ;;ido               ; the other *other* search engine...
        ;;ivy               ; a search engine for love and life
@@ -60,7 +60,7 @@
        (format +onsave)  ; automated prettiness
        ;;god               ; run Emacs commands without modifier keys
        ;;lispy             ; vim for lisp, for people who don't like vim
-       ;;multiple-cursors  ; editing in many places at once
+       multiple-cursors  ; editing in many places at once
        ;;objed             ; text object editing for the innocent
        ;;parinfer          ; turn lisp into python, sort of
        ;;rotate-text       ; cycle region at point between text candidates
@@ -94,18 +94,18 @@
        ;;collab            ; buffers with friends
        debugger          ; stepping through code, to help you add bugs
        direnv
-       docker            ; Dockerfile/compose editing + tramp into containers
-       ;;editorconfig      ; let someone else argue about tabs vs spaces
+       (docker +lsp)     ; Dockerfile/compose editing + tramp into containers
+       editorconfig      ; let someone else argue about tabs vs spaces
        ;;ein               ; tame Jupyter notebooks with emacs
        (eval +overlay)     ; run code, run (also, repls)
        lookup              ; navigate your code and its documentation
        ;;llm               ; when I said you needed friends, I didn't mean...
        (lsp +eglot)        ; M-x vscode (eglot backend: lighter + faster)
-       magit             ; a git porcelain for Emacs
-       ;;make              ; run make tasks from Emacs
+       (magit +forge)    ; a git porcelain for Emacs (+ GitHub/GitLab PRs & issues)
+       make              ; run make tasks from Emacs
        ;;pass              ; password manager for nerds
        ;;pdf               ; pdf enhancements
-       ;;terraform         ; infrastructure as code
+       terraform         ; infrastructure as code
        tmux              ; an API for interacting with tmux
        tree-sitter       ; syntax and parsing, sitting in a tree...
        ;;upload            ; map local to remote projects via ssh/ftp
@@ -138,7 +138,7 @@
        ;;fsharp            ; ML stands for Microsoft's Language
        ;;fstar             ; (dependent) types and (monadic) effects and Z3
        ;;gdscript          ; the language you waited for
-       (go +lsp)         ; the hipster dialect
+       (go +lsp +tree-sitter)  ; the hipster dialect
        ;;(graphql +lsp)    ; Give queries a REST
        ;;(haskell +lsp)    ; a language that's lazier than I am
        ;;hy                ; readability of scheme w/ speed of python
@@ -169,16 +169,16 @@
        rest              ; Emacs as a REST client
        ;;rst               ; ReST in peace
        ;;(ruby +rails)     ; 1.step {|i| p "Ruby is #{i.even? ? 'love' : 'life'}"}
-       (rust +lsp)        ; Fe2O3.unwrap().unwrap().unwrap().unwrap()
+       (rust +lsp +tree-sitter)  ; Fe2O3.unwrap().unwrap().unwrap().unwrap()
        ;;scala             ; java, but good
        ;;(scheme +guile)   ; a fully conniving family of lisps
-       sh                ; she sells {ba,z,fi}sh shells on the C xor
+       (sh +lsp)         ; she sells {ba,z,fi}sh shells on the C xor
        ;;sml
        ;;solidity          ; do you need a blockchain? No.
        ;;swift             ; who asked for emoji variables?
        ;;terra             ; Earth and Moon in alignment for performance.
        ;;web               ; the tubes
-       yaml              ; JSON, but readable
+       (yaml +lsp)       ; JSON, but readable
        ;;zig               ; C, but simpler
 
        :email

--- a/dot_config/doom/packages.el
+++ b/dot_config/doom/packages.el
@@ -47,9 +47,6 @@
 ;; Prettier Go test output
 (package! gotest)
 
-;; Icons in completion popup
-(package! kind-icon)
-
 ;; Floating hover doc frame (replaces lsp-ui-doc-glance)
 (package! eldoc-box)
 
@@ -68,11 +65,13 @@
 (package! pg)
 (package! pgmacs :recipe (:host github :repo "emarsden/pgmacs"))
 
-;; Go struct tag management (add/remove/rename json/db/etc tags)
-(package! go-tag)
+;; go-tag (struct tags) and flycheck-golangci-lint are already bundled by
+;; Doom's `:lang go' module, so they're not re-declared here.
 
-;; golangci-lint flycheck integration
-(package! flycheck-golangci-lint)
+;; Generate interface method stubs (needs the `impl' binary) and fill struct
+;; literals with zero-value fields (needs the `fillstruct' binary).
+(package! go-impl)
+(package! go-fill-struct)
 
 ;; Keep cursor vertically centered
 (package! centered-cursor-mode)
@@ -91,3 +90,10 @@
 
 (package! gotest-ui
   :recipe (:host github :repo "antifuchs/gotest-ui-mode"))
+
+;; Kubernetes — magit-style cluster management UI (pods/deployments/services…)
+(package! kubernetes)
+(package! kubernetes-evil)   ; evil keybindings for the kubernetes overview
+
+;; docker-compose-mode — keyword/indentation support for compose files
+(package! docker-compose-mode)


### PR DESCRIPTION
## Summary
- **chezmoi install docs**: `README.md` install commands now pass `--source ~/.config/dotfiles`. Without it, `chezmoi init` clones to the default `~/.local/share/chezmoi`, which mismatches the `sourceDir` set in `.chezmoi.toml.tmpl` and makes all dotfiles appear *unmanaged* on fresh machines. Now matches `install.sh`.
- **Doom Emacs**: enable several modules and add Go codegen helpers; remove packages that Doom already bundles.

## Doom changes
- `init.el`: enable `multiple-cursors`, `editorconfig`, `make`, `terraform`, `(magit +forge)`, `(sh +lsp)`, `(corfu +icons)`, and `+tree-sitter` for `go`/`rust`.
- `config.el`:
  - new `go-debug-test-at-point` dape config + `+go/test-name-at-point` helper
  - `go-impl` / `go-fill-struct` keybinds under `SPC m i`
  - drop manual `kind-icon` setup (now via `corfu +icons` → nerd-icons-corfu)
  - drop `flycheck-golangci-lint` use-package (bundled by `:lang go`)
- `packages.el`: add `go-impl`, `go-fill-struct`; drop `kind-icon`, `go-tag`, `flycheck-golangci-lint`.
- `doom/README.md`: document yaml/docker/kubernetes modules and cargo/k8s keybinds.

## Verification
- `chezmoi apply` → clean (`chezmoi status` empty)
- `doom sync` → all 212 packages up-to-date, init rebuilt, no errors
- `doom doctor` → **0 errors**, only optional-tooling warnings (terraform-ls, shfmt/shellcheck, fillstruct binaries not installed — features degrade gracefully until installed)